### PR TITLE
Use Zone ID for DNS Aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Available targets:
 | name | Application or solution name (e.g. `app`) | string | `ecs` | no |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | overwrite_ssm_parameter | Whether to overwrite an existing SSM parameter | string | `true` | no |
-| parent_zone_id | The zone ID of the `domain_name`. Leave blank and it will be looked up using the `domain_name`. Define it to avoid cold-start problems. | string | `` | no |
+| parent_zone_id | The zone ID where the DNS record for the `short_name` will be written`. | string | `` | no |
 | policy_arn | Permission to grant to atlantis server | string | `arn:aws:iam::aws:policy/AdministratorAccess` | no |
 | private_subnet_ids | The private subnet IDs | list | `<list>` | no |
 | region | AWS Region for Atlantis deployment | string | `us-west-2` | no |

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | atlantis_ssh_public_key | Atlantis SSH Public Key |
-| badge_url | the url of the build badge when badge_enabled is enabled |
+| atlantis_url | The URL endpoint for the atlantis server |
+| badge_url | The URL of the build badge when `badge_enabled` is enabled |
 
 
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Available targets:
 | name | Application or solution name (e.g. `app`) | string | `ecs` | no |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | overwrite_ssm_parameter | Whether to overwrite an existing SSM parameter | string | `true` | no |
+| parent_zone_id | The zone ID of the `domain_name`. Leave blank and it will be looked up using the `domain_name`. Define it to avoid cold-start problems. | string | `` | no |
 | policy_arn | Permission to grant to atlantis server | string | `arn:aws:iam::aws:policy/AdministratorAccess` | no |
 | private_subnet_ids | The private subnet IDs | list | `<list>` | no |
 | region | AWS Region for Atlantis deployment | string | `us-west-2` | no |

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Available targets:
 | name | Application or solution name (e.g. `app`) | string | `ecs` | no |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | overwrite_ssm_parameter | Whether to overwrite an existing SSM parameter | string | `true` | no |
-| parent_zone_id | The zone ID where the DNS record for the `short_name` will be written`. | string | `` | no |
+| parent_zone_id | The zone ID where the DNS record for the `short_name` will be written | string | `` | no |
 | policy_arn | Permission to grant to atlantis server | string | `arn:aws:iam::aws:policy/AdministratorAccess` | no |
 | private_subnet_ids | The private subnet IDs | list | `<list>` | no |
 | region | AWS Region for Atlantis deployment | string | `us-west-2` | no |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ Available targets:
 | default_backend_image | ECS default (bootstrap) image | string | `cloudposse/default-backend:0.1.2` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | desired_count | Atlantis desired number of tasks | string | `1` | no |
-| domain_name | A domain name for which the certificate should be issued | string | - | yes |
 | ecs_cluster_arn | ARN of the ECS cluster to deploy Atlantis | string | - | yes |
 | ecs_cluster_name | Name of the ECS cluster to deploy Atlantis | string | - | yes |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -65,5 +65,6 @@
 | Name | Description |
 |------|-------------|
 | atlantis_ssh_public_key | Atlantis SSH Public Key |
-| badge_url | the url of the build badge when badge_enabled is enabled |
+| atlantis_url | The URL endpoint for the atlantis server |
+| badge_url | The URL of the build badge when `badge_enabled` is enabled |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -45,6 +45,7 @@
 | name | Application or solution name (e.g. `app`) | string | `ecs` | no |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | overwrite_ssm_parameter | Whether to overwrite an existing SSM parameter | string | `true` | no |
+| parent_zone_id | The zone ID of the `domain_name`. Leave blank and it will be looked up using the `domain_name`. Define it to avoid cold-start problems. | string | `` | no |
 | policy_arn | Permission to grant to atlantis server | string | `arn:aws:iam::aws:policy/AdministratorAccess` | no |
 | private_subnet_ids | The private subnet IDs | list | `<list>` | no |
 | region | AWS Region for Atlantis deployment | string | `us-west-2` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -44,7 +44,7 @@
 | name | Application or solution name (e.g. `app`) | string | `ecs` | no |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | overwrite_ssm_parameter | Whether to overwrite an existing SSM parameter | string | `true` | no |
-| parent_zone_id | The zone ID of the `domain_name`. Leave blank and it will be looked up using the `domain_name`. Define it to avoid cold-start problems. | string | `` | no |
+| parent_zone_id | The zone ID where the DNS record for the `short_name` will be written`. | string | `` | no |
 | policy_arn | Permission to grant to atlantis server | string | `arn:aws:iam::aws:policy/AdministratorAccess` | no |
 | private_subnet_ids | The private subnet IDs | list | `<list>` | no |
 | region | AWS Region for Atlantis deployment | string | `us-west-2` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -44,7 +44,7 @@
 | name | Application or solution name (e.g. `app`) | string | `ecs` | no |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | overwrite_ssm_parameter | Whether to overwrite an existing SSM parameter | string | `true` | no |
-| parent_zone_id | The zone ID where the DNS record for the `short_name` will be written`. | string | `` | no |
+| parent_zone_id | The zone ID where the DNS record for the `short_name` will be written | string | `` | no |
 | policy_arn | Permission to grant to atlantis server | string | `arn:aws:iam::aws:policy/AdministratorAccess` | no |
 | private_subnet_ids | The private subnet IDs | list | `<list>` | no |
 | region | AWS Region for Atlantis deployment | string | `us-west-2` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -33,7 +33,6 @@
 | default_backend_image | ECS default (bootstrap) image | string | `cloudposse/default-backend:0.1.2` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | desired_count | Atlantis desired number of tasks | string | `1` | no |
-| domain_name | A domain name for which the certificate should be issued | string | - | yes |
 | ecs_cluster_arn | ARN of the ECS cluster to deploy Atlantis | string | - | yes |
 | ecs_cluster_name | Name of the ECS cluster to deploy Atlantis | string | - | yes |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ locals {
   atlantis_gh_webhook_secret  = "${length(var.atlantis_gh_webhook_secret) > 0 ? var.atlantis_gh_webhook_secret : join("", random_string.atlantis_gh_webhook_secret.*.result)}"
   atlantis_url                = "${format(var.atlantis_webhook_format, local.hostname)}"
   attributes                  = "${concat(list(var.short_name), var.attributes)}"
-  default_hostname            = "${var.short_name}.${var.domain_name}"
+  default_hostname            = "${join("", aws_route53_record.default.*.fqdn)}"
   github_oauth_token          = "${length(join("", data.aws_ssm_parameter.atlantis_gh_token.*.value)) > 0 ? join("", data.aws_ssm_parameter.atlantis_gh_token.*.value) : var.github_oauth_token}"
   github_oauth_token_ssm_name = "${length(var.github_oauth_token_ssm_name) > 0 ? var.github_oauth_token_ssm_name : format(var.chamber_format, var.chamber_service, "atlantis_gh_token")}"
   hostname                    = "${length(var.hostname) > 0 ? var.hostname : local.default_hostname}"
@@ -45,13 +45,26 @@ module "ssh_key_pair" {
 }
 
 module "hostname" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=avoid-data"
-  enabled          = "${local.enabled}"
-  aliases          = ["${local.hostname}"]
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=avoid-data"
+  enabled = "${local.enabled}"
+  aliases = ["${local.hostname}"]
+
   #parent_zone_name = "${var.domain_name}"
-  parent_zone_id   = "${var.parent_zone_id}"
-  target_dns_name  = "${var.alb_dns_name}"
-  target_zone_id   = "${var.alb_zone_id}"
+  parent_zone_id  = "${var.parent_zone_id}"
+  target_dns_name = "${var.alb_dns_name}"
+  target_zone_id  = "${var.alb_zone_id}"
+}
+
+resource "aws_route53_record" "default" {
+  count   = "${local.enabled ? 1 : 0}"
+  zone_id = "${var.parent_zone_id}"
+  name    = "${var.short_name}"
+  type    = "A"
+
+  alias {
+    name    = "${var.alb_dns_name}"
+    zone_id = "${var.alb_zone_id}"
+  }
 }
 
 module "webhooks" {

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "hostname" {
   enabled          = "${local.enabled}"
   aliases          = ["${local.hostname}"]
   parent_zone_name = "${var.domain_name}"
+  parent_zone_id   = "${var.parent_zone_id}"
   target_dns_name  = "${var.alb_dns_name}"
   target_zone_id   = "${var.alb_zone_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -44,19 +44,6 @@ module "ssh_key_pair" {
   ssm_path_prefix      = "${var.chamber_service}"
 }
 
-resource "aws_route53_record" "default" {
-  count   = "${local.enabled ? 1 : 0}"
-  zone_id = "${var.parent_zone_id}"
-  name    = "${var.short_name}"
-  type    = "A"
-
-  alias {
-    name                   = "${var.alb_dns_name}"
-    zone_id                = "${var.alb_zone_id}"
-    evaluate_target_health = "false"
-  }
-}
-
 module "webhooks" {
   source              = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.1.1"
   github_token        = "${local.github_oauth_token}"
@@ -150,6 +137,20 @@ module "web_app" {
 
 # Resources
 #--------------------------------------------------------------
+
+resource "aws_route53_record" "default" {
+  count   = "${local.enabled ? 1 : 0}"
+  zone_id = "${var.parent_zone_id}"
+  name    = "${var.short_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${var.alb_dns_name}"
+    zone_id                = "${var.alb_zone_id}"
+    evaluate_target_health = "false"
+  }
+}
+
 resource "random_string" "atlantis_gh_webhook_secret" {
   count   = "${local.enabled ? 1 : 0}"
   length  = "${var.webhook_secret_length}"

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ module "ssh_key_pair" {
 }
 
 module "hostname" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.2.7"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=avoid-data"
   enabled          = "${local.enabled}"
   aliases          = ["${local.hostname}"]
   #parent_zone_name = "${var.domain_name}"

--- a/main.tf
+++ b/main.tf
@@ -44,17 +44,6 @@ module "ssh_key_pair" {
   ssm_path_prefix      = "${var.chamber_service}"
 }
 
-module "hostname" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=avoid-data"
-  enabled = "${local.enabled}"
-  aliases = ["${local.hostname}"]
-
-  #parent_zone_name = "${var.domain_name}"
-  parent_zone_id  = "${var.parent_zone_id}"
-  target_dns_name = "${var.alb_dns_name}"
-  target_zone_id  = "${var.alb_zone_id}"
-}
-
 resource "aws_route53_record" "default" {
   count   = "${local.enabled ? 1 : 0}"
   zone_id = "${var.parent_zone_id}"
@@ -62,8 +51,9 @@ resource "aws_route53_record" "default" {
   type    = "A"
 
   alias {
-    name    = "${var.alb_dns_name}"
-    zone_id = "${var.alb_zone_id}"
+    name                   = "${var.alb_dns_name}"
+    zone_id                = "${var.alb_zone_id}"
+    evaluate_target_health = "false"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ module "hostname" {
   source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.2.7"
   enabled          = "${local.enabled}"
   aliases          = ["${local.hostname}"]
-  parent_zone_name = "${var.domain_name}"
+  #parent_zone_name = "${var.domain_name}"
   parent_zone_id   = "${var.parent_zone_id}"
   target_dns_name  = "${var.alb_dns_name}"
   target_zone_id   = "${var.alb_zone_id}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,11 @@ output "atlantis_ssh_public_key" {
 }
 
 output "badge_url" {
-  description = "the url of the build badge when badge_enabled is enabled"
+  description = "The URL of the build badge when `badge_enabled` is enabled"
   value       = "${module.web_app.badge_url}"
+}
+
+output "atlantis_url" {
+  description = "The URL endpoint for the atlantis server"
+  value       = "${local.atlantis_url}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -319,7 +319,7 @@ variable "region" {
 
 variable "parent_zone_id" {
   type        = "string"
-  description = "The zone ID where the DNS record for the `short_name` will be written`."
+  description = "The zone ID where the DNS record for the `short_name` will be written"
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -322,6 +322,12 @@ variable "domain_name" {
   description = "A domain name for which the certificate should be issued"
 }
 
+variable "parent_zone_id" {
+  type = "string"
+  description = "The zone ID of the `domain_name`. Leave blank and it will be looked up using the `domain_name`. Define it to avoid cold-start problems."
+  default = ""
+}
+
 variable "overwrite_ssm_parameter" {
   type        = "string"
   default     = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -319,7 +319,7 @@ variable "region" {
 
 variable "parent_zone_id" {
   type        = "string"
-  description = "The zone ID of the `domain_name`. Leave blank and it will be looked up using the `domain_name`. Define it to avoid cold-start problems."
+  description = "The zone ID where the DNS record for the `short_name` will be written`."
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -317,11 +317,6 @@ variable "region" {
   default     = "us-west-2"
 }
 
-variable "domain_name" {
-  type        = "string"
-  description = "A domain name for which the certificate should be issued"
-}
-
 variable "parent_zone_id" {
   type        = "string"
   description = "The zone ID of the `domain_name`. Leave blank and it will be looked up using the `domain_name`. Define it to avoid cold-start problems."

--- a/variables.tf
+++ b/variables.tf
@@ -323,9 +323,9 @@ variable "domain_name" {
 }
 
 variable "parent_zone_id" {
-  type = "string"
+  type        = "string"
   description = "The zone ID of the `domain_name`. Leave blank and it will be looked up using the `domain_name`. Define it to avoid cold-start problems."
-  default = ""
+  default     = ""
 }
 
 variable "overwrite_ssm_parameter" {


### PR DESCRIPTION
## what
* Use `zone_id` instead of `zone_name`
* Use `aws_route53_record` directly due to `terraform-aws-route53-alias` having "count of" problems in a cold-start when parent zone does not yet exist
* Add an `atlantis_url` output

## why
* Using `zone_name` won't work in a cold-start scenario due to the `data` provider doing lookups for a zone that does not yet exist
* It's not more difficult for the caller to pass a `zone_id`