### PR TITLE
Add authentication with Cognito and OIDC. Add usage examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Cloud Posse, LLC
+   Copyright 2018-2019 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Introduction
 
 
-Atlantis enables GitOps workflows so that teams can collaborate on operations using Pull Requests. 
+Atlantis enables GitOps workflows so that teams can collaborate on operations using Pull Requests.
 
 Under the hood, it's a small self-hosted daemon (`#golang`) that listens for Pull Request webhook events from GitHub.
 
@@ -75,13 +75,13 @@ This module provisions the following resources:
 - GitHub webhook to trigger Atlantis for a given repository
 
 What this module does not provision:
-  
+
   - ECS Cluster (BYOC)
   - ALB
   - ACM certificate
   - VPC
   - Subnets
-  
+
 ## Caveats
 
 - This project assumes that the repo being deployed defines a `Dockerfile` which runs `atlantis`. It might not work with the official version of atlantis. We use [`geodesic`](https://github.com/cloudposse/geodesic) as our docker base image.
@@ -103,12 +103,19 @@ We suggest creating a personal access token for a GitHub bot user with the follo
 
 ![GitHub Repo Scopes](docs/github-repo-scopes.png)
 
-**IMPORTANT:** Do not commit this `github_oauth_token` to source control (e.g. via `terraform.tvfars`). 
+**IMPORTANT:** Do not commit this `github_oauth_token` to source control (e.g. via `terraform.tvfars`).
 
 ## Usage
 
 
-**NOTE:** if no `github_oauth_token` is set, this module attempts to look one up from SSM. 
+Module usage examples:
+
+- [without authentication](examples/without_authentication) - complete example without authentication
+- [with Google OIDC authentication](examples/with_google_oidc_authentication) - complete example with Google OIDC authentication
+- [with Cognito authentication](examples/with_cognito_authentication) - complete example with Cognito authentication
+
+
+**NOTE:** if no `github_oauth_token` is set, this module attempts to look one up from SSM.
 
 ```
 module "atlantis" {
@@ -163,6 +170,7 @@ Available targets:
 | alb_dns_name | DNS name of ALB | string | - | yes |
 | alb_ingress_paths | Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set | list | `<list>` | no |
 | alb_listener_arns | A list of ALB listener ARNs | list | - | yes |
+| alb_listener_arns_count | Number of elements in the list of ALB Listener ARNs for the ECS service | string | `2` | no |
 | alb_name | The Name of the ALB | string | - | yes |
 | alb_target_group_alarms_alarm_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an ALARM state from any other state. | list | `<list>` | no |
 | alb_target_group_alarms_insufficient_data_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an INSUFFICIENT_DATA state from any other state. | list | `<list>` | no |
@@ -179,6 +187,8 @@ Available targets:
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
+| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true` | map | `<map>` | no |
+| authentication_enabled | Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC | string | `false` | no |
 | autoscaling_max_capacity | Atlantis maximum tasks to run | string | `1` | no |
 | autoscaling_min_capacity | Atlantis minimum tasks to run | string | `1` | no |
 | branch | Atlantis branch of the GitHub repository, _e.g._ `master` | string | `master` | no |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,12 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | alb_arn_suffix | The ARN suffix of the ALB | string | - | yes |
 | alb_dns_name | DNS name of ALB | string | - | yes |
-| alb_ingress_paths | Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set | list | `<list>` | no |
+| alb_ingress_authenticated_hosts | Authenticated hosts to match in Hosts header (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_listener_authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `100` | no |
+| alb_ingress_listener_unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority | string | `50` | no |
+| alb_ingress_unauthenticated_hosts | Unauthenticated hosts to match in Hosts header (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_listener_arns | A list of ALB listener ARNs | list | - | yes |
 | alb_listener_arns_count | Number of elements in the list of ALB Listener ARNs for the ECS service | string | `2` | no |
 | alb_name | The Name of the ALB | string | - | yes |
@@ -187,8 +192,7 @@ Available targets:
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true` | map | `<map>` | no |
-| authentication_enabled | Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC | string | `false` | no |
+| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided | map | `<map>` | no |
 | autoscaling_max_capacity | Atlantis maximum tasks to run | string | `1` | no |
 | autoscaling_min_capacity | Atlantis minimum tasks to run | string | `1` | no |
 | branch | Atlantis branch of the GitHub repository, _e.g._ `master` | string | `master` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -73,8 +73,8 @@ description: |-
 
 introduction: |-
 
-  Atlantis enables GitOps workflows so that teams can collaborate on operations using Pull Requests. 
-  
+  Atlantis enables GitOps workflows so that teams can collaborate on operations using Pull Requests.
+
   Under the hood, it's a small self-hosted daemon (`#golang`) that listens for Pull Request webhook events from GitHub.
 
   With Atlantis, engineers can run `terraform plan` and `terraform apply` using "chat ops" type comments on the Pull Request.
@@ -98,19 +98,19 @@ introduction: |-
   - GitHub webhook to trigger Atlantis for a given repository
 
   What this module does not provision:
-    
+
     - ECS Cluster (BYOC)
     - ALB
     - ACM certificate
     - VPC
     - Subnets
-    
+
   ## Caveats
 
   - This project assumes that the repo being deployed defines a `Dockerfile` which runs `atlantis`. It might not work with the official version of atlantis. We use [`geodesic`](https://github.com/cloudposse/geodesic) as our docker base image.
   - This project defines parameters which are not available in the *official version* of `atlantis`. Our [fork](https://github.com/cloudposse/atlantis) implements the ability to restrict `plan` and `apply` to GitHub teams.
 
-  
+
   ### GitHub Repo Scopes
 
   We suggest creating a personal access token for a GitHub bot user with the following scopes:
@@ -126,13 +126,20 @@ introduction: |-
 
   ![GitHub Repo Scopes](docs/github-repo-scopes.png)
 
-  **IMPORTANT:** Do not commit this `github_oauth_token` to source control (e.g. via `terraform.tvfars`). 
+  **IMPORTANT:** Do not commit this `github_oauth_token` to source control (e.g. via `terraform.tvfars`).
 
 # How to use this project
 usage: |-
 
-  **NOTE:** if no `github_oauth_token` is set, this module attempts to look one up from SSM. 
-  
+  Module usage examples:
+
+  - [without authentication](examples/without_authentication) - complete example without authentication
+  - [with Google OIDC authentication](examples/with_google_oidc_authentication) - complete example with Google OIDC authentication
+  - [with Cognito authentication](examples/with_cognito_authentication) - complete example with Cognito authentication
+
+
+  **NOTE:** if no `github_oauth_token` is set, this module attempts to look one up from SSM.
+
   ```
   module "atlantis" {
     source = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=master"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,12 @@
 |------|-------------|:----:|:-----:|:-----:|
 | alb_arn_suffix | The ARN suffix of the ALB | string | - | yes |
 | alb_dns_name | DNS name of ALB | string | - | yes |
-| alb_ingress_paths | Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set | list | `<list>` | no |
+| alb_ingress_authenticated_hosts | Authenticated hosts to match in Hosts header (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_listener_authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `100` | no |
+| alb_ingress_listener_unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority | string | `50` | no |
+| alb_ingress_unauthenticated_hosts | Unauthenticated hosts to match in Hosts header (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_listener_arns | A list of ALB listener ARNs | list | - | yes |
 | alb_listener_arns_count | Number of elements in the list of ALB Listener ARNs for the ECS service | string | `2` | no |
 | alb_name | The Name of the ALB | string | - | yes |
@@ -23,8 +28,7 @@
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true` | map | `<map>` | no |
-| authentication_enabled | Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC | string | `false` | no |
+| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided | map | `<map>` | no |
 | autoscaling_max_capacity | Atlantis maximum tasks to run | string | `1` | no |
 | autoscaling_min_capacity | Atlantis minimum tasks to run | string | `1` | no |
 | branch | Atlantis branch of the GitHub repository, _e.g._ `master` | string | `master` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,6 +6,7 @@
 | alb_dns_name | DNS name of ALB | string | - | yes |
 | alb_ingress_paths | Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set | list | `<list>` | no |
 | alb_listener_arns | A list of ALB listener ARNs | list | - | yes |
+| alb_listener_arns_count | Number of elements in the list of ALB Listener ARNs for the ECS service | string | `2` | no |
 | alb_name | The Name of the ALB | string | - | yes |
 | alb_target_group_alarms_alarm_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an ALARM state from any other state. | list | `<list>` | no |
 | alb_target_group_alarms_insufficient_data_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an INSUFFICIENT_DATA state from any other state. | list | `<list>` | no |
@@ -22,6 +23,8 @@
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
+| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true` | map | `<map>` | no |
+| authentication_enabled | Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC | string | `false` | no |
 | autoscaling_max_capacity | Atlantis maximum tasks to run | string | `1` | no |
 | autoscaling_min_capacity | Atlantis minimum tasks to run | string | `1` | no |
 | branch | Atlantis branch of the GitHub repository, _e.g._ `master` | string | `master` | no |

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -1,0 +1,113 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.4"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  availability_zones = "${slice(data.aws_availability_zones.available.names, 0, 2)}"
+}
+
+module "subnets" {
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
+  availability_zones  = "${local.availability_zones}"
+  namespace           = "${var.namespace}"
+  stage               = "${var.stage}"
+  name                = "${var.name}"
+  region              = "${var.region}"
+  vpc_id              = "${module.vpc.vpc_id}"
+  igw_id              = "${module.vpc.igw_id}"
+  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  nat_gateway_enabled = "true"
+}
+
+module "alb" {
+  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.2.6"
+  name                      = "${var.name}"
+  namespace                 = "${var.namespace}"
+  stage                     = "${var.stage}"
+  attributes                = ["${compact(concat(var.attributes, list("alb")))}"]
+  vpc_id                    = "${module.vpc.vpc_id}"
+  ip_address_type           = "ipv4"
+  subnet_ids                = ["${module.subnets.public_subnet_ids}"]
+  security_group_ids        = ["${module.vpc.vpc_default_security_group_id}"]
+  access_logs_region        = "${var.region}"
+  https_enabled             = "true"
+  http_ingress_cidr_blocks  = ["0.0.0.0/0"]
+  https_ingress_cidr_blocks = ["0.0.0.0/0"]
+  certificate_arn           = "${var.certificate_arn}"
+  health_check_interval     = "60"
+}
+
+module "ecs_cluster_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+  attributes = "${var.attributes}"
+  delimiter  = "${var.delimiter}"
+}
+
+# ECS Cluster (needed even if using FARGATE launch type)
+resource "aws_ecs_cluster" "default" {
+  name = "${module.ecs_cluster_label.id}"
+}
+
+module "atlantis" {
+  source    = "../.."
+  enabled   = "true"
+  name      = "${var.name}"
+  namespace = "${var.namespace}"
+  region    = "${var.region}"
+  stage     = "${var.stage}"
+
+  atlantis_gh_team_whitelist = "${var.atlantis_gh_team_whitelist}"
+  atlantis_gh_user           = "${var.atlantis_gh_user}"
+  atlantis_repo_whitelist    = ["${var.atlantis_repo_whitelist}"]
+
+  alb_arn_suffix = "${module.alb.alb_arn_suffix}"
+  alb_dns_name   = "${module.alb.alb_dns_name}"
+  alb_name       = "${module.alb.alb_name}"
+  alb_zone_id    = "${module.alb.alb_zone_id}"
+
+  container_cpu    = "${var.atlantis_container_cpu}"
+  container_memory = "${var.atlantis_container_memory}"
+
+  branch             = "${var.atlantis_branch}"
+  parent_zone_id     = "${var.parent_zone_id}"
+  ecs_cluster_arn    = "${aws_ecs_cluster.default.arn}"
+  ecs_cluster_name   = "${aws_ecs_cluster.default.name}"
+  repo_name          = "${var.atlantis_repo_name}"
+  repo_owner         = "${var.atlantis_repo_owner}"
+  private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
+  security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
+  vpc_id             = "${module.vpc.vpc_id}"
+
+  # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
+  alb_listener_arns       = ["${module.alb.https_listener_arn}"]
+  alb_listener_arns_count = 1
+
+  authentication_enabled = "true"
+
+  # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
+  authentication_action = {
+    type = "authenticate-cognito"
+
+    authenticate_cognito = [{
+      user_pool_arn       = "${var.cognito_user_pool_arn}"
+      user_pool_client_id = "${var.cognito_user_pool_client_id}"
+
+      # NOTE: The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com)
+      user_pool_domain = "${var.cognito_user_pool_domain}"
+    }]
+  }
+}

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -96,7 +96,13 @@ module "atlantis" {
   alb_listener_arns       = ["${module.alb.https_listener_arn}"]
   alb_listener_arns_count = 1
 
-  authentication_enabled = "true"
+  # Unauthenticated paths
+  alb_ingress_unauthenticated_paths             = ["/events"]
+  alb_ingress_listener_unauthenticated_priority = "50"
+
+  # Authenticated paths
+  alb_ingress_authenticated_paths             = ["/*"]
+  alb_ingress_listener_authenticated_priority = "100"
 
   # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
   authentication_action = {

--- a/examples/with_cognito_authentication/outputs.tf
+++ b/examples/with_cognito_authentication/outputs.tf
@@ -1,0 +1,3 @@
+output "atlantis_url" {
+  value = "${module.atlantis.atlantis_url}"
+}

--- a/examples/with_cognito_authentication/variables.tf
+++ b/examples/with_cognito_authentication/variables.tf
@@ -1,0 +1,114 @@
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+  default     = "ex2"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+  default     = "testing"
+}
+
+variable "name" {
+  type        = "string"
+  description = "Application or solution name (e.g. `app`)"
+  default     = "ecs"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
+}
+
+variable "region" {
+  type        = "string"
+  description = "AWS Region"
+  default     = "us-west-2"
+}
+
+variable "certificate_arn" {
+  type        = "string"
+  description = "SSL certificate ARN for ALB HTTPS endpoints"
+}
+
+variable "cognito_user_pool_arn" {
+  type        = "string"
+  description = "Cognito User Pool ARN"
+}
+
+variable "cognito_user_pool_client_id" {
+  type        = "string"
+  description = "Cognito User Pool Client ID"
+}
+
+variable "cognito_user_pool_domain" {
+  type        = "string"
+  description = "Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com)"
+}
+
+variable "atlantis_gh_team_whitelist" {
+  type        = "string"
+  description = "Atlantis GitHub team whitelist"
+  default     = "engineering:plan,devops:*"
+}
+
+variable "atlantis_gh_user" {
+  type        = "string"
+  description = "Atlantis GitHub user"
+  default     = "examplebot"
+}
+
+variable "atlantis_repo_whitelist" {
+  type        = "list"
+  description = "Whitelist of repositories Atlantis will accept webhooks from"
+  default     = ["github.com/example/*"]
+}
+
+variable "atlantis_repo_name" {
+  type        = "string"
+  description = "GitHub repository name of the atlantis to be built and deployed to ECS"
+  default     = "atlantis"
+}
+
+variable "atlantis_repo_owner" {
+  type        = "string"
+  description = "GitHub organization containing the Atlantis repository"
+  default     = "cloudposse"
+}
+
+variable "atlantis_branch" {
+  type        = "string"
+  description = "Atlantis branch of the GitHub repository, _e.g._ `master`"
+  default     = "master"
+}
+
+variable "atlantis_container_cpu" {
+  type        = "string"
+  description = "The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
+  default     = "256"
+}
+
+variable "atlantis_container_memory" {
+  type        = "string"
+  description = "The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
+  default     = "512"
+}
+
+variable "parent_zone_id" {
+  type        = "string"
+  description = "The zone ID where the DNS record for the atlantis `short_name` will be written"
+}

--- a/examples/with_cognito_authentication/variables.tf
+++ b/examples/with_cognito_authentication/variables.tf
@@ -1,7 +1,7 @@
 variable "namespace" {
   type        = "string"
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  default     = "ex2"
+  default     = "eg"
 }
 
 variable "stage" {
@@ -13,7 +13,7 @@ variable "stage" {
 variable "name" {
   type        = "string"
   description = "Application or solution name (e.g. `app`)"
-  default     = "ecs"
+  default     = "atlantis"
 }
 
 variable "delimiter" {

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -62,70 +62,6 @@ resource "aws_ecs_cluster" "default" {
   name = "${module.ecs_cluster_label.id}"
 }
 
-provider "aws" {
-  region = "${var.region}"
-}
-
-module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.4"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  cidr_block = "172.16.0.0/16"
-}
-
-data "aws_availability_zones" "available" {}
-
-locals {
-  availability_zones = "${slice(data.aws_availability_zones.available.names, 0, 2)}"
-}
-
-module "subnets" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
-  availability_zones  = "${local.availability_zones}"
-  namespace           = "${var.namespace}"
-  stage               = "${var.stage}"
-  name                = "${var.name}"
-  region              = "${var.region}"
-  vpc_id              = "${module.vpc.vpc_id}"
-  igw_id              = "${module.vpc.igw_id}"
-  cidr_block          = "${module.vpc.vpc_cidr_block}"
-  nat_gateway_enabled = "true"
-}
-
-module "alb" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.2.6"
-  name                      = "${var.name}"
-  namespace                 = "${var.namespace}"
-  stage                     = "${var.stage}"
-  attributes                = ["${compact(concat(var.attributes, list("alb")))}"]
-  vpc_id                    = "${module.vpc.vpc_id}"
-  ip_address_type           = "ipv4"
-  subnet_ids                = ["${module.subnets.public_subnet_ids}"]
-  security_group_ids        = ["${module.vpc.vpc_default_security_group_id}"]
-  access_logs_region        = "${var.region}"
-  https_enabled             = "true"
-  http_ingress_cidr_blocks  = ["0.0.0.0/0"]
-  https_ingress_cidr_blocks = ["0.0.0.0/0"]
-  certificate_arn           = "${var.certificate_arn}"
-  health_check_interval     = "60"
-}
-
-module "ecs_cluster_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-}
-
-# ECS Cluster (needed even if using FARGATE launch type)
-resource "aws_ecs_cluster" "default" {
-  name = "${module.ecs_cluster_label.id}"
-}
-
 module "atlantis" {
   source    = "../.."
   enabled   = "true"
@@ -160,7 +96,13 @@ module "atlantis" {
   alb_listener_arns       = ["${module.alb.https_listener_arn}"]
   alb_listener_arns_count = 1
 
-  authentication_enabled = "true"
+  # Unauthenticated paths
+  alb_ingress_unauthenticated_paths             = ["/events"]
+  alb_ingress_listener_unauthenticated_priority = "50"
+
+  # Authenticated paths
+  alb_ingress_authenticated_paths             = ["/*"]
+  alb_ingress_listener_authenticated_priority = "100"
 
   # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
   authentication_action = {

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -1,0 +1,181 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.4"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  availability_zones = "${slice(data.aws_availability_zones.available.names, 0, 2)}"
+}
+
+module "subnets" {
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
+  availability_zones  = "${local.availability_zones}"
+  namespace           = "${var.namespace}"
+  stage               = "${var.stage}"
+  name                = "${var.name}"
+  region              = "${var.region}"
+  vpc_id              = "${module.vpc.vpc_id}"
+  igw_id              = "${module.vpc.igw_id}"
+  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  nat_gateway_enabled = "true"
+}
+
+module "alb" {
+  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.2.6"
+  name                      = "${var.name}"
+  namespace                 = "${var.namespace}"
+  stage                     = "${var.stage}"
+  attributes                = ["${compact(concat(var.attributes, list("alb")))}"]
+  vpc_id                    = "${module.vpc.vpc_id}"
+  ip_address_type           = "ipv4"
+  subnet_ids                = ["${module.subnets.public_subnet_ids}"]
+  security_group_ids        = ["${module.vpc.vpc_default_security_group_id}"]
+  access_logs_region        = "${var.region}"
+  https_enabled             = "true"
+  http_ingress_cidr_blocks  = ["0.0.0.0/0"]
+  https_ingress_cidr_blocks = ["0.0.0.0/0"]
+  certificate_arn           = "${var.certificate_arn}"
+  health_check_interval     = "60"
+}
+
+module "ecs_cluster_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+  attributes = "${var.attributes}"
+  delimiter  = "${var.delimiter}"
+}
+
+# ECS Cluster (needed even if using FARGATE launch type)
+resource "aws_ecs_cluster" "default" {
+  name = "${module.ecs_cluster_label.id}"
+}
+
+provider "aws" {
+  region = "${var.region}"
+}
+
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.4"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  availability_zones = "${slice(data.aws_availability_zones.available.names, 0, 2)}"
+}
+
+module "subnets" {
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
+  availability_zones  = "${local.availability_zones}"
+  namespace           = "${var.namespace}"
+  stage               = "${var.stage}"
+  name                = "${var.name}"
+  region              = "${var.region}"
+  vpc_id              = "${module.vpc.vpc_id}"
+  igw_id              = "${module.vpc.igw_id}"
+  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  nat_gateway_enabled = "true"
+}
+
+module "alb" {
+  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.2.6"
+  name                      = "${var.name}"
+  namespace                 = "${var.namespace}"
+  stage                     = "${var.stage}"
+  attributes                = ["${compact(concat(var.attributes, list("alb")))}"]
+  vpc_id                    = "${module.vpc.vpc_id}"
+  ip_address_type           = "ipv4"
+  subnet_ids                = ["${module.subnets.public_subnet_ids}"]
+  security_group_ids        = ["${module.vpc.vpc_default_security_group_id}"]
+  access_logs_region        = "${var.region}"
+  https_enabled             = "true"
+  http_ingress_cidr_blocks  = ["0.0.0.0/0"]
+  https_ingress_cidr_blocks = ["0.0.0.0/0"]
+  certificate_arn           = "${var.certificate_arn}"
+  health_check_interval     = "60"
+}
+
+module "ecs_cluster_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+  attributes = "${var.attributes}"
+  delimiter  = "${var.delimiter}"
+}
+
+# ECS Cluster (needed even if using FARGATE launch type)
+resource "aws_ecs_cluster" "default" {
+  name = "${module.ecs_cluster_label.id}"
+}
+
+module "atlantis" {
+  source    = "../.."
+  enabled   = "true"
+  name      = "${var.name}"
+  namespace = "${var.namespace}"
+  region    = "${var.region}"
+  stage     = "${var.stage}"
+
+  atlantis_gh_team_whitelist = "${var.atlantis_gh_team_whitelist}"
+  atlantis_gh_user           = "${var.atlantis_gh_user}"
+  atlantis_repo_whitelist    = ["${var.atlantis_repo_whitelist}"]
+
+  alb_arn_suffix = "${module.alb.alb_arn_suffix}"
+  alb_dns_name   = "${module.alb.alb_dns_name}"
+  alb_name       = "${module.alb.alb_name}"
+  alb_zone_id    = "${module.alb.alb_zone_id}"
+
+  container_cpu    = "${var.atlantis_container_cpu}"
+  container_memory = "${var.atlantis_container_memory}"
+
+  branch             = "${var.atlantis_branch}"
+  parent_zone_id     = "${var.parent_zone_id}"
+  ecs_cluster_arn    = "${aws_ecs_cluster.default.arn}"
+  ecs_cluster_name   = "${aws_ecs_cluster.default.name}"
+  repo_name          = "${var.atlantis_repo_name}"
+  repo_owner         = "${var.atlantis_repo_owner}"
+  private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
+  security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
+  vpc_id             = "${module.vpc.vpc_id}"
+
+  # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
+  alb_listener_arns       = ["${module.alb.https_listener_arn}"]
+  alb_listener_arns_count = 1
+
+  authentication_enabled = "true"
+
+  # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
+  authentication_action = {
+    type = "authenticate-oidc"
+
+    authenticate_oidc = [{
+      # Use this URL to create a Google OAuth 2.0 Client and obtain the Client ID and Client Secret: https://console.developers.google.com/apis/credentials
+      client_id     = "${var.google_oidc_client_id}"
+      client_secret = "${var.google_oidc_client_secret}"
+
+      # Use this URL to get Google Auth endpoints: https://accounts.google.com/.well-known/openid-configuration
+      issuer                 = "https://accounts.google.com"
+      authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+      token_endpoint         = "https://oauth2.googleapis.com/token"
+      user_info_endpoint     = "https://openidconnect.googleapis.com/v1/userinfo"
+    }]
+  }
+}

--- a/examples/with_google_oidc_authentication/outputs.tf
+++ b/examples/with_google_oidc_authentication/outputs.tf
@@ -1,0 +1,3 @@
+output "atlantis_url" {
+  value = "${module.atlantis.atlantis_url}"
+}

--- a/examples/with_google_oidc_authentication/variables.tf
+++ b/examples/with_google_oidc_authentication/variables.tf
@@ -1,0 +1,109 @@
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+  default     = "ex2"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+  default     = "testing"
+}
+
+variable "name" {
+  type        = "string"
+  description = "Application or solution name (e.g. `app`)"
+  default     = "ecs"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
+}
+
+variable "region" {
+  type        = "string"
+  description = "AWS Region"
+  default     = "us-west-2"
+}
+
+variable "certificate_arn" {
+  type        = "string"
+  description = "SSL certificate ARN for ALB HTTPS endpoints"
+}
+
+variable "google_oidc_client_id" {
+  type        = "string"
+  description = "Google OIDC Client ID. Use this URL to create a Google OAuth 2.0 Client and obtain the Client ID and Client Secret: https://console.developers.google.com/apis/credentials"
+}
+
+variable "google_oidc_client_secret" {
+  type        = "string"
+  description = "Google OIDC Client Secret. Use this URL to create a Google OAuth 2.0 Client and obtain the Client ID and Client Secret: https://console.developers.google.com/apis/credentials"
+}
+
+variable "atlantis_gh_team_whitelist" {
+  type        = "string"
+  description = "Atlantis GitHub team whitelist"
+  default     = "engineering:plan,devops:*"
+}
+
+variable "atlantis_gh_user" {
+  type        = "string"
+  description = "Atlantis GitHub user"
+  default     = "examplebot"
+}
+
+variable "atlantis_repo_whitelist" {
+  type        = "list"
+  description = "Whitelist of repositories Atlantis will accept webhooks from"
+  default     = ["github.com/example/*"]
+}
+
+variable "atlantis_repo_name" {
+  type        = "string"
+  description = "GitHub repository name of the atlantis to be built and deployed to ECS"
+  default     = "atlantis"
+}
+
+variable "atlantis_repo_owner" {
+  type        = "string"
+  description = "GitHub organization containing the Atlantis repository"
+  default     = "cloudposse"
+}
+
+variable "atlantis_branch" {
+  type        = "string"
+  description = "Atlantis branch of the GitHub repository, _e.g._ `master`"
+  default     = "master"
+}
+
+variable "atlantis_container_cpu" {
+  type        = "string"
+  description = "The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
+  default     = "256"
+}
+
+variable "atlantis_container_memory" {
+  type        = "string"
+  description = "The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
+  default     = "512"
+}
+
+variable "parent_zone_id" {
+  type        = "string"
+  description = "The zone ID where the DNS record for the atlantis `short_name` will be written"
+}

--- a/examples/with_google_oidc_authentication/variables.tf
+++ b/examples/with_google_oidc_authentication/variables.tf
@@ -1,7 +1,7 @@
 variable "namespace" {
   type        = "string"
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  default     = "ex2"
+  default     = "eg"
 }
 
 variable "stage" {
@@ -13,7 +13,7 @@ variable "stage" {
 variable "name" {
   type        = "string"
   description = "Application or solution name (e.g. `app`)"
-  default     = "ecs"
+  default     = "atlantis"
 }
 
 variable "delimiter" {

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -1,0 +1,99 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+module "vpc" {
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.3.4"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  cidr_block = "172.16.0.0/16"
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  availability_zones = "${slice(data.aws_availability_zones.available.names, 0, 2)}"
+}
+
+module "subnets" {
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
+  availability_zones  = "${local.availability_zones}"
+  namespace           = "${var.namespace}"
+  stage               = "${var.stage}"
+  name                = "${var.name}"
+  region              = "${var.region}"
+  vpc_id              = "${module.vpc.vpc_id}"
+  igw_id              = "${module.vpc.igw_id}"
+  cidr_block          = "${module.vpc.vpc_cidr_block}"
+  nat_gateway_enabled = "true"
+}
+
+module "alb" {
+  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.2.6"
+  name                      = "${var.name}"
+  namespace                 = "${var.namespace}"
+  stage                     = "${var.stage}"
+  attributes                = ["${compact(concat(var.attributes, list("alb")))}"]
+  vpc_id                    = "${module.vpc.vpc_id}"
+  ip_address_type           = "ipv4"
+  subnet_ids                = ["${module.subnets.public_subnet_ids}"]
+  security_group_ids        = ["${module.vpc.vpc_default_security_group_id}"]
+  access_logs_region        = "${var.region}"
+  https_enabled             = "true"
+  http_ingress_cidr_blocks  = ["0.0.0.0/0"]
+  https_ingress_cidr_blocks = ["0.0.0.0/0"]
+  certificate_arn           = "${var.certificate_arn}"
+  health_check_interval     = "60"
+}
+
+module "ecs_cluster_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.2.1"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+  attributes = "${var.attributes}"
+  delimiter  = "${var.delimiter}"
+}
+
+# ECS Cluster (needed even if using FARGATE launch type)
+resource "aws_ecs_cluster" "default" {
+  name = "${module.ecs_cluster_label.id}"
+}
+
+module "atlantis" {
+  source    = "../.."
+  enabled   = "true"
+  name      = "${var.name}"
+  namespace = "${var.namespace}"
+  region    = "${var.region}"
+  stage     = "${var.stage}"
+
+  atlantis_gh_team_whitelist = "${var.atlantis_gh_team_whitelist}"
+  atlantis_gh_user           = "${var.atlantis_gh_user}"
+  atlantis_repo_whitelist    = ["${var.atlantis_repo_whitelist}"]
+
+  alb_arn_suffix = "${module.alb.alb_arn_suffix}"
+  alb_dns_name   = "${module.alb.alb_dns_name}"
+  alb_name       = "${module.alb.alb_name}"
+  alb_zone_id    = "${module.alb.alb_zone_id}"
+
+  container_cpu    = "${var.atlantis_container_cpu}"
+  container_memory = "${var.atlantis_container_memory}"
+
+  branch             = "${var.atlantis_branch}"
+  parent_zone_id     = "${var.parent_zone_id}"
+  ecs_cluster_arn    = "${aws_ecs_cluster.default.arn}"
+  ecs_cluster_name   = "${aws_ecs_cluster.default.name}"
+  repo_name          = "${var.atlantis_repo_name}"
+  repo_owner         = "${var.atlantis_repo_owner}"
+  private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
+  security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
+  vpc_id             = "${module.vpc.vpc_id}"
+
+  alb_listener_arns = ["${module.alb.listener_arns}"]
+
+  # If using without authentication, we support both HTTP and HTTPS endpoints for Atlantis
+  alb_listener_arns_count = 2
+}

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -96,4 +96,8 @@ module "atlantis" {
 
   # If using without authentication, we support both HTTP and HTTPS endpoints for Atlantis
   alb_listener_arns_count = 2
+
+  alb_ingress_unauthenticated_paths             = ["/*"]
+  alb_ingress_listener_unauthenticated_priority = "50"
+  alb_ingress_authenticated_paths               = []
 }

--- a/examples/without_authentication/outputs.tf
+++ b/examples/without_authentication/outputs.tf
@@ -1,0 +1,3 @@
+output "atlantis_url" {
+  value = "${module.atlantis.atlantis_url}"
+}

--- a/examples/without_authentication/variables.tf
+++ b/examples/without_authentication/variables.tf
@@ -1,0 +1,99 @@
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+  default     = "ex2"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+  default     = "testing"
+}
+
+variable "name" {
+  type        = "string"
+  description = "Application or solution name (e.g. `app`)"
+  default     = "ecs"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
+}
+
+variable "region" {
+  type        = "string"
+  description = "AWS Region"
+  default     = "us-west-2"
+}
+
+variable "certificate_arn" {
+  type        = "string"
+  description = "SSL certificate ARN for ALB HTTPS endpoints"
+}
+
+variable "atlantis_gh_team_whitelist" {
+  type        = "string"
+  description = "Atlantis GitHub team whitelist"
+  default     = "engineering:plan,devops:*"
+}
+
+variable "atlantis_gh_user" {
+  type        = "string"
+  description = "Atlantis GitHub user"
+  default     = "examplebot"
+}
+
+variable "atlantis_repo_whitelist" {
+  type        = "list"
+  description = "Whitelist of repositories Atlantis will accept webhooks from"
+  default     = ["github.com/example/*"]
+}
+
+variable "atlantis_repo_name" {
+  type        = "string"
+  description = "GitHub repository name of the atlantis to be built and deployed to ECS"
+  default     = "atlantis"
+}
+
+variable "atlantis_repo_owner" {
+  type        = "string"
+  description = "GitHub organization containing the Atlantis repository"
+  default     = "cloudposse"
+}
+
+variable "atlantis_branch" {
+  type        = "string"
+  description = "Atlantis branch of the GitHub repository, _e.g._ `master`"
+  default     = "master"
+}
+
+variable "atlantis_container_cpu" {
+  type        = "string"
+  description = "The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
+  default     = "256"
+}
+
+variable "atlantis_container_memory" {
+  type        = "string"
+  description = "The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
+  default     = "512"
+}
+
+variable "parent_zone_id" {
+  type        = "string"
+  description = "The zone ID where the DNS record for the atlantis `short_name` will be written"
+}

--- a/examples/without_authentication/variables.tf
+++ b/examples/without_authentication/variables.tf
@@ -1,7 +1,7 @@
 variable "namespace" {
   type        = "string"
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  default     = "ex2"
+  default     = "eg"
 }
 
 variable "stage" {
@@ -13,7 +13,7 @@ variable "stage" {
 variable "name" {
   type        = "string"
   description = "Application or solution name (e.g. `app`)"
-  default     = "ecs"
+  default     = "atlantis"
 }
 
 variable "delimiter" {

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ module "webhooks" {
 }
 
 module "web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.11.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.14.0"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -101,7 +101,7 @@ module "web_app" {
   autoscaling_scale_down_cooldown   = "300"
 
   listener_arns          = "${var.alb_listener_arns}"
-  listener_arns_count    = "2"
+  listener_arns_count    = "${var.alb_listener_arns_count}"
   aws_logs_region        = "${var.region}"
   ecs_alarms_enabled     = "${local.enabled}"
   ecs_cluster_arn        = "${var.ecs_cluster_arn}"
@@ -133,6 +133,9 @@ module "web_app" {
   alb_target_group_alarms_alarm_actions             = ["${var.alb_target_group_alarms_alarm_actions}"]
   alb_target_group_alarms_ok_actions                = ["${var.alb_target_group_alarms_ok_actions}"]
   alb_target_group_alarms_insufficient_data_actions = ["${var.alb_target_group_alarms_insufficient_data_actions}"]
+
+  authentication_enabled = "${var.authentication_enabled}"
+  authentication_action  = "${var.authentication_action}"
 }
 
 # Resources

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ module "webhooks" {
 }
 
 module "web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.15.0"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -109,9 +109,7 @@ module "web_app" {
   ecs_security_group_ids = ["${var.security_group_ids}"]
   ecs_private_subnet_ids = ["${var.private_subnet_ids}"]
 
-  alb_ingress_healthcheck_path  = "${var.healthcheck_path}"
-  alb_ingress_paths             = ["${var.alb_ingress_paths}"]
-  alb_ingress_listener_priority = "100"
+  alb_ingress_healthcheck_path = "${var.healthcheck_path}"
 
   github_oauth_token = "${local.github_oauth_token}"
   repo_owner         = "${var.repo_owner}"
@@ -134,8 +132,15 @@ module "web_app" {
   alb_target_group_alarms_ok_actions                = ["${var.alb_target_group_alarms_ok_actions}"]
   alb_target_group_alarms_insufficient_data_actions = ["${var.alb_target_group_alarms_insufficient_data_actions}"]
 
-  authentication_enabled = "${var.authentication_enabled}"
-  authentication_action  = "${var.authentication_action}"
+  # Unauthenticated paths
+  alb_ingress_unauthenticated_paths             = ["${var.alb_ingress_unauthenticated_paths}"]
+  alb_ingress_listener_unauthenticated_priority = "${var.alb_ingress_listener_unauthenticated_priority}"
+
+  # Authenticated paths
+  alb_ingress_authenticated_paths             = ["${var.alb_ingress_authenticated_paths}"]
+  alb_ingress_listener_authenticated_priority = "${var.alb_ingress_listener_authenticated_priority}"
+
+  authentication_action = "${var.authentication_action}"
 }
 
 # Resources

--- a/variables.tf
+++ b/variables.tf
@@ -251,12 +251,6 @@ variable "alb_listener_arns_count" {
   default     = 2
 }
 
-variable "alb_ingress_paths" {
-  type        = "list"
-  default     = ["/*"]
-  description = "Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set"
-}
-
 variable "alb_name" {
   type        = "string"
   description = "The Name of the ALB"
@@ -335,14 +329,44 @@ variable "overwrite_ssm_parameter" {
   description = "Whether to overwrite an existing SSM parameter"
 }
 
-variable "authentication_enabled" {
+variable "alb_ingress_listener_unauthenticated_priority" {
   type        = "string"
-  default     = "false"
-  description = "Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC"
+  default     = "50"
+  description = "The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority"
+}
+
+variable "alb_ingress_listener_authenticated_priority" {
+  type        = "string"
+  default     = "100"
+  description = "The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority"
+}
+
+variable "alb_ingress_unauthenticated_hosts" {
+  type        = "list"
+  default     = []
+  description = "Unauthenticated hosts to match in Hosts header (a maximum of 1 can be defined)"
+}
+
+variable "alb_ingress_authenticated_hosts" {
+  type        = "list"
+  default     = []
+  description = "Authenticated hosts to match in Hosts header (a maximum of 1 can be defined)"
+}
+
+variable "alb_ingress_unauthenticated_paths" {
+  type        = "list"
+  default     = ["/events"]
+  description = "Unauthenticated path pattern to match (a maximum of 1 can be defined)"
+}
+
+variable "alb_ingress_authenticated_paths" {
+  type        = "list"
+  default     = ["/*"]
+  description = "Authenticated path pattern to match (a maximum of 1 can be defined)"
 }
 
 variable "authentication_action" {
   type        = "map"
   default     = {}
-  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true`"
+  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -245,6 +245,12 @@ variable "alb_listener_arns" {
   description = "A list of ALB listener ARNs"
 }
 
+variable "alb_listener_arns_count" {
+  type        = "string"
+  description = "Number of elements in the list of ALB Listener ARNs for the ECS service"
+  default     = 2
+}
+
 variable "alb_ingress_paths" {
   type        = "list"
   default     = ["/*"]
@@ -327,4 +333,16 @@ variable "overwrite_ssm_parameter" {
   type        = "string"
   default     = "true"
   description = "Whether to overwrite an existing SSM parameter"
+}
+
+variable "authentication_enabled" {
+  type        = "string"
+  default     = "false"
+  description = "Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC"
+}
+
+variable "authentication_action" {
+  type        = "map"
+  default     = {}
+  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true`"
 }


### PR DESCRIPTION
## what
* Add `Cognito` and `OIDC` authentication
* Add usage examples

## why
* To be able to authenticate the Atlantis ALB endpoint with Cognito or OIDC (e.g. Google, GitHub)
* Complete examples show how to use the module without authentication and with Cognito and Google OIDC authentication