### PR TITLE
Fix authentication action.  Don't use `map` variable for authentication action

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ We suggest creating a personal access token for a GitHub bot user with the follo
 ## Usage
 
 
+**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
+Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-ecs-atlantis/releases).
+
+
+
 Module usage examples:
 
 - [without authentication](examples/without_authentication) - complete example without authentication
@@ -119,7 +124,7 @@ Module usage examples:
 
 ```
 module "atlantis" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=master"
+  source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=master"
   enabled   = "true"
   name      = "${var.name}"
   namespace = "${var.namespace}"
@@ -132,7 +137,6 @@ module "atlantis" {
 
   alb_arn_suffix    = "${module.alb.alb_arn_suffix}"
   alb_dns_name      = "${module.alb.alb_dns_name}"
-  alb_listener_arns = ["${module.alb.listener_arns}"]
   alb_name          = "${module.alb.alb_name}"
   alb_zone_id       = "${module.alb.alb_zone_id}"
 
@@ -144,6 +148,12 @@ module "atlantis" {
   private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
   security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   vpc_id             = "${module.vpc.vpc_id}"
+
+  alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+  alb_ingress_unauthenticated_listener_arns_count = 2
+  alb_ingress_unauthenticated_paths               = ["/*"]
+  alb_ingress_listener_unauthenticated_priority   = "100"
+  alb_ingress_authenticated_paths                 = []
 }
 ```
 
@@ -169,13 +179,15 @@ Available targets:
 | alb_arn_suffix | The ARN suffix of the ALB | string | - | yes |
 | alb_dns_name | DNS name of ALB | string | - | yes |
 | alb_ingress_authenticated_hosts | Authenticated hosts to match in Hosts header (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_authenticated_listener_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| alb_ingress_authenticated_listener_arns_count | The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | alb_ingress_authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_ingress_listener_authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `100` | no |
 | alb_ingress_listener_unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority | string | `50` | no |
 | alb_ingress_unauthenticated_hosts | Unauthenticated hosts to match in Hosts header (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_unauthenticated_listener_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| alb_ingress_unauthenticated_listener_arns_count | The number of unauthenticated ARNs in `alb_ingress_unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | alb_ingress_unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
-| alb_listener_arns | A list of ALB listener ARNs | list | - | yes |
-| alb_listener_arns_count | Number of elements in the list of ALB Listener ARNs for the ECS service | string | `2` | no |
 | alb_name | The Name of the ALB | string | - | yes |
 | alb_target_group_alarms_alarm_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an ALARM state from any other state. | list | `<list>` | no |
 | alb_target_group_alarms_insufficient_data_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an INSUFFICIENT_DATA state from any other state. | list | `<list>` | no |
@@ -192,7 +204,16 @@ Available targets:
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided | map | `<map>` | no |
+| authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
+| authentication_cognito_user_pool_client_id | Cognito User Pool Client ID | string | `` | no |
+| authentication_cognito_user_pool_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | string | `` | no |
+| authentication_oidc_authorization_endpoint | OIDC Authorization Endpoint | string | `` | no |
+| authentication_oidc_client_id | OIDC Client ID | string | `` | no |
+| authentication_oidc_client_secret | OIDC Client Secret | string | `` | no |
+| authentication_oidc_issuer | OIDC Issuer | string | `` | no |
+| authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
+| authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
 | autoscaling_max_capacity | Atlantis maximum tasks to run | string | `1` | no |
 | autoscaling_min_capacity | Atlantis minimum tasks to run | string | `1` | no |
 | branch | Atlantis branch of the GitHub repository, _e.g._ `master` | string | `master` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -142,7 +142,7 @@ usage: |-
 
   ```
   module "atlantis" {
-    source = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=master"
+    source    = "git::https://github.com/cloudposse/terraform-aws-ecs-atlantis.git?ref=master"
     enabled   = "true"
     name      = "${var.name}"
     namespace = "${var.namespace}"
@@ -155,7 +155,6 @@ usage: |-
 
     alb_arn_suffix    = "${module.alb.alb_arn_suffix}"
     alb_dns_name      = "${module.alb.alb_dns_name}"
-    alb_listener_arns = ["${module.alb.listener_arns}"]
     alb_name          = "${module.alb.alb_name}"
     alb_zone_id       = "${module.alb.alb_zone_id}"
 
@@ -167,6 +166,12 @@ usage: |-
     private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
     security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
     vpc_id             = "${module.vpc.vpc_id}"
+
+    alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+    alb_ingress_unauthenticated_listener_arns_count = 2
+    alb_ingress_unauthenticated_paths               = ["/*"]
+    alb_ingress_listener_unauthenticated_priority   = "100"
+    alb_ingress_authenticated_paths                 = []
   }
   ```
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,13 +5,15 @@
 | alb_arn_suffix | The ARN suffix of the ALB | string | - | yes |
 | alb_dns_name | DNS name of ALB | string | - | yes |
 | alb_ingress_authenticated_hosts | Authenticated hosts to match in Hosts header (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_authenticated_listener_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| alb_ingress_authenticated_listener_arns_count | The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | alb_ingress_authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_ingress_listener_authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `100` | no |
 | alb_ingress_listener_unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority | string | `50` | no |
 | alb_ingress_unauthenticated_hosts | Unauthenticated hosts to match in Hosts header (a maximum of 1 can be defined) | list | `<list>` | no |
+| alb_ingress_unauthenticated_listener_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| alb_ingress_unauthenticated_listener_arns_count | The number of unauthenticated ARNs in `alb_ingress_unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | alb_ingress_unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
-| alb_listener_arns | A list of ALB listener ARNs | list | - | yes |
-| alb_listener_arns_count | Number of elements in the list of ALB Listener ARNs for the ECS service | string | `2` | no |
 | alb_name | The Name of the ALB | string | - | yes |
 | alb_target_group_alarms_alarm_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an ALARM state from any other state. | list | `<list>` | no |
 | alb_target_group_alarms_insufficient_data_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an INSUFFICIENT_DATA state from any other state. | list | `<list>` | no |
@@ -28,7 +30,16 @@
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided | map | `<map>` | no |
+| authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
+| authentication_cognito_user_pool_client_id | Cognito User Pool Client ID | string | `` | no |
+| authentication_cognito_user_pool_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | string | `` | no |
+| authentication_oidc_authorization_endpoint | OIDC Authorization Endpoint | string | `` | no |
+| authentication_oidc_client_id | OIDC Client ID | string | `` | no |
+| authentication_oidc_client_secret | OIDC Client Secret | string | `` | no |
+| authentication_oidc_issuer | OIDC Issuer | string | `` | no |
+| authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
+| authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
 | autoscaling_max_capacity | Atlantis maximum tasks to run | string | `1` | no |
 | autoscaling_min_capacity | Atlantis minimum tasks to run | string | `1` | no |
 | branch | Atlantis branch of the GitHub repository, _e.g._ `master` | string | `master` | no |

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -92,11 +92,13 @@ module "atlantis" {
   security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   vpc_id             = "${module.vpc.vpc_id}"
 
-  # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
-  alb_listener_arns       = ["${module.alb.https_listener_arn}"]
-  alb_listener_arns_count = 1
+  alb_ingress_authenticated_listener_arns       = ["${module.alb.https_listener_arn}"]
+  alb_ingress_authenticated_listener_arns_count = 1
 
-  # Unauthenticated paths
+  alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+  alb_ingress_unauthenticated_listener_arns_count = 2
+
+  # Unauthenticated paths (with higher priority than the authenticated paths)
   alb_ingress_unauthenticated_paths             = ["/events"]
   alb_ingress_listener_unauthenticated_priority = "50"
 
@@ -104,16 +106,8 @@ module "atlantis" {
   alb_ingress_authenticated_paths             = ["/*"]
   alb_ingress_listener_authenticated_priority = "100"
 
-  # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
-  authentication_action = {
-    type = "authenticate-cognito"
-
-    authenticate_cognito = [{
-      user_pool_arn       = "${var.cognito_user_pool_arn}"
-      user_pool_client_id = "${var.cognito_user_pool_client_id}"
-
-      # NOTE: The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com)
-      user_pool_domain = "${var.cognito_user_pool_domain}"
-    }]
-  }
+  authentication_type                        = "COGNITO"
+  authentication_cognito_user_pool_arn       = "${var.cognito_user_pool_arn}"
+  authentication_cognito_user_pool_client_id = "${var.cognito_user_pool_client_id}"
+  authentication_cognito_user_pool_domain    = "${var.cognito_user_pool_domain}"
 }

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -92,11 +92,13 @@ module "atlantis" {
   security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   vpc_id             = "${module.vpc.vpc_id}"
 
-  # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
-  alb_listener_arns       = ["${module.alb.https_listener_arn}"]
-  alb_listener_arns_count = 1
+  alb_ingress_authenticated_listener_arns       = ["${module.alb.https_listener_arn}"]
+  alb_ingress_authenticated_listener_arns_count = 1
 
-  # Unauthenticated paths
+  alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+  alb_ingress_unauthenticated_listener_arns_count = 2
+
+  # Unauthenticated paths (with higher priority than the authenticated paths)
   alb_ingress_unauthenticated_paths             = ["/events"]
   alb_ingress_listener_unauthenticated_priority = "50"
 
@@ -104,20 +106,11 @@ module "atlantis" {
   alb_ingress_authenticated_paths             = ["/*"]
   alb_ingress_listener_authenticated_priority = "100"
 
-  # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
-  authentication_action = {
-    type = "authenticate-oidc"
-
-    authenticate_oidc = [{
-      # Use this URL to create a Google OAuth 2.0 Client and obtain the Client ID and Client Secret: https://console.developers.google.com/apis/credentials
-      client_id     = "${var.google_oidc_client_id}"
-      client_secret = "${var.google_oidc_client_secret}"
-
-      # Use this URL to get Google Auth endpoints: https://accounts.google.com/.well-known/openid-configuration
-      issuer                 = "https://accounts.google.com"
-      authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
-      token_endpoint         = "https://oauth2.googleapis.com/token"
-      user_info_endpoint     = "https://openidconnect.googleapis.com/v1/userinfo"
-    }]
-  }
+  authentication_type                        = "OIDC"
+  authentication_oidc_client_id              = "${var.google_oidc_client_id}"
+  authentication_oidc_client_secret          = "${var.google_oidc_client_secret}"
+  authentication_oidc_issuer                 = "https://accounts.google.com"
+  authentication_oidc_authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+  authentication_oidc_token_endpoint         = "https://oauth2.googleapis.com/token"
+  authentication_oidc_user_info_endpoint     = "https://openidconnect.googleapis.com/v1/userinfo"
 }

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -92,12 +92,12 @@ module "atlantis" {
   security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   vpc_id             = "${module.vpc.vpc_id}"
 
-  alb_listener_arns = ["${module.alb.listener_arns}"]
+  # Without authentication, both HTTP and HTTPS endpoints are supported
+  alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+  alb_ingress_unauthenticated_listener_arns_count = 2
 
-  # If using without authentication, we support both HTTP and HTTPS endpoints for Atlantis
-  alb_listener_arns_count = 2
-
+  # All paths are unauthenticated
   alb_ingress_unauthenticated_paths             = ["/*"]
-  alb_ingress_listener_unauthenticated_priority = "50"
+  alb_ingress_listener_unauthenticated_priority = "100"
   alb_ingress_authenticated_paths               = []
 }

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ module "webhooks" {
 }
 
 module "web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.15.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.17.0"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -100,8 +100,6 @@ module "web_app" {
   autoscaling_scale_down_adjustment = "-1"
   autoscaling_scale_down_cooldown   = "300"
 
-  listener_arns          = "${var.alb_listener_arns}"
-  listener_arns_count    = "${var.alb_listener_arns_count}"
   aws_logs_region        = "${var.region}"
   ecs_alarms_enabled     = "${local.enabled}"
   ecs_cluster_arn        = "${var.ecs_cluster_arn}"
@@ -132,15 +130,29 @@ module "web_app" {
   alb_target_group_alarms_ok_actions                = ["${var.alb_target_group_alarms_ok_actions}"]
   alb_target_group_alarms_insufficient_data_actions = ["${var.alb_target_group_alarms_insufficient_data_actions}"]
 
-  # Unauthenticated paths
-  alb_ingress_unauthenticated_paths             = ["${var.alb_ingress_unauthenticated_paths}"]
+  alb_ingress_authenticated_paths   = ["${var.alb_ingress_authenticated_paths}"]
+  alb_ingress_unauthenticated_paths = ["${var.alb_ingress_unauthenticated_paths}"]
+  alb_ingress_authenticated_hosts   = ["${var.alb_ingress_authenticated_hosts}"]
+  alb_ingress_unauthenticated_hosts = ["${var.alb_ingress_unauthenticated_hosts}"]
+
+  alb_ingress_listener_authenticated_priority   = "${var.alb_ingress_listener_authenticated_priority}"
   alb_ingress_listener_unauthenticated_priority = "${var.alb_ingress_listener_unauthenticated_priority}"
 
-  # Authenticated paths
-  alb_ingress_authenticated_paths             = ["${var.alb_ingress_authenticated_paths}"]
-  alb_ingress_listener_authenticated_priority = "${var.alb_ingress_listener_authenticated_priority}"
+  alb_ingress_unauthenticated_listener_arns       = "${var.alb_ingress_unauthenticated_listener_arns}"
+  alb_ingress_unauthenticated_listener_arns_count = "${var.alb_ingress_unauthenticated_listener_arns_count}"
+  alb_ingress_authenticated_listener_arns         = "${var.alb_ingress_authenticated_listener_arns}"
+  alb_ingress_authenticated_listener_arns_count   = "${var.alb_ingress_authenticated_listener_arns_count}"
 
-  authentication_action = "${var.authentication_action}"
+  authentication_type                        = "${var.authentication_type}"
+  authentication_cognito_user_pool_arn       = "${var.authentication_cognito_user_pool_arn}"
+  authentication_cognito_user_pool_client_id = "${var.authentication_cognito_user_pool_client_id}"
+  authentication_cognito_user_pool_domain    = "${var.authentication_cognito_user_pool_domain}"
+  authentication_oidc_client_id              = "${var.authentication_oidc_client_id}"
+  authentication_oidc_client_secret          = "${var.authentication_oidc_client_secret}"
+  authentication_oidc_issuer                 = "${var.authentication_oidc_issuer}"
+  authentication_oidc_authorization_endpoint = "${var.authentication_oidc_authorization_endpoint}"
+  authentication_oidc_token_endpoint         = "${var.authentication_oidc_token_endpoint}"
+  authentication_oidc_user_info_endpoint     = "${var.authentication_oidc_user_info_endpoint}"
 }
 
 # Resources

--- a/variables.tf
+++ b/variables.tf
@@ -240,17 +240,6 @@ variable "vpc_id" {
   description = "VPC ID for the ECS Cluster"
 }
 
-variable "alb_listener_arns" {
-  type        = "list"
-  description = "A list of ALB listener ARNs"
-}
-
-variable "alb_listener_arns_count" {
-  type        = "string"
-  description = "Number of elements in the list of ALB Listener ARNs for the ECS service"
-  default     = 2
-}
-
 variable "alb_name" {
   type        = "string"
   description = "The Name of the ALB"
@@ -365,8 +354,86 @@ variable "alb_ingress_authenticated_paths" {
   description = "Authenticated path pattern to match (a maximum of 1 can be defined)"
 }
 
-variable "authentication_action" {
-  type        = "map"
-  default     = {}
-  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided"
+variable "alb_ingress_unauthenticated_listener_arns" {
+  type        = "list"
+  default     = []
+  description = "A list of unauthenticated ALB listener ARNs to attach ALB listener rules to"
+}
+
+variable "alb_ingress_unauthenticated_listener_arns_count" {
+  type        = "string"
+  default     = "0"
+  description = "The number of unauthenticated ARNs in `alb_ingress_unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
+}
+
+variable "alb_ingress_authenticated_listener_arns" {
+  type        = "list"
+  default     = []
+  description = "A list of authenticated ALB listener ARNs to attach ALB listener rules to"
+}
+
+variable "alb_ingress_authenticated_listener_arns_count" {
+  type        = "string"
+  default     = "0"
+  description = "The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
+}
+
+variable "authentication_type" {
+  type        = "string"
+  default     = "NONE"
+  description = "Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE`"
+}
+
+variable "authentication_cognito_user_pool_arn" {
+  type        = "string"
+  description = "Cognito User Pool ARN"
+  default     = ""
+}
+
+variable "authentication_cognito_user_pool_client_id" {
+  type        = "string"
+  description = "Cognito User Pool Client ID"
+  default     = ""
+}
+
+variable "authentication_cognito_user_pool_domain" {
+  type        = "string"
+  description = "Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com)"
+  default     = ""
+}
+
+variable "authentication_oidc_client_id" {
+  type        = "string"
+  description = "OIDC Client ID"
+  default     = ""
+}
+
+variable "authentication_oidc_client_secret" {
+  type        = "string"
+  description = "OIDC Client Secret"
+  default     = ""
+}
+
+variable "authentication_oidc_issuer" {
+  type        = "string"
+  description = "OIDC Issuer"
+  default     = ""
+}
+
+variable "authentication_oidc_authorization_endpoint" {
+  type        = "string"
+  description = "OIDC Authorization Endpoint"
+  default     = ""
+}
+
+variable "authentication_oidc_token_endpoint" {
+  type        = "string"
+  description = "OIDC Token Endpoint"
+  default     = ""
+}
+
+variable "authentication_oidc_user_info_endpoint" {
+  type        = "string"
+  description = "OIDC User Info Endpoint"
+  default     = ""
 }


### PR DESCRIPTION
## what
* Fix authentication action
* Don't use `map` variable for authentication action

## why
* Using `authentication_action` variable as `map` breaks when this module is used in a chain of calls from other modules
For example:
   * Providing `authentication_action` map from Module B to `alb-ingress` - works
   * Providing `authentication_action` map from Module C to Module B to `alb-ingress` - works
   * Providing `authentication_action` map from Module D to Module C to Module B to `alb-ingress` - breaks (in a way that is very difficult to understand and debug; the end result is that `alb-ingress` receives an empty or incomplete map)

