### PR TITLE
Bump `terraform-aws-ecs-web-app` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Available targets:
 | authentication_oidc_issuer | OIDC Issuer | string | `` | no |
 | authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
 | authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
-| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO` and `OIDC` | string | `` | no |
 | autoscaling_max_capacity | Atlantis maximum tasks to run | string | `1` | no |
 | autoscaling_min_capacity | Atlantis minimum tasks to run | string | `1` | no |
 | branch | Atlantis branch of the GitHub repository, _e.g._ `master` | string | `master` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -39,7 +39,7 @@
 | authentication_oidc_issuer | OIDC Issuer | string | `` | no |
 | authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
 | authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
-| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO` and `OIDC` | string | `` | no |
 | autoscaling_max_capacity | Atlantis maximum tasks to run | string | `1` | no |
 | autoscaling_min_capacity | Atlantis minimum tasks to run | string | `1` | no |
 | branch | Atlantis branch of the GitHub repository, _e.g._ `master` | string | `master` | no |

--- a/main.tf
+++ b/main.tf
@@ -7,12 +7,12 @@ terraform {
 # Data
 #--------------------------------------------------------------
 data "aws_ssm_parameter" "atlantis_gh_token" {
-  count = "${local.enabled && length(var.github_oauth_token) > 0 ? 0 : 1}"
+  count = "${local.enabled && length(var.github_oauth_token) == 0 ? 1 : 0}"
   name  = "${local.github_oauth_token_ssm_name}"
 }
 
 data "aws_kms_key" "chamber_kms_key" {
-  count  = "${local.enabled && length(var.kms_key_id) > 0 ? 0 : 1}"
+  count  = "${local.enabled && length(var.kms_key_id) == 0 ? 1 : 0}"
   key_id = "${local.kms_key_id}"
 }
 
@@ -56,7 +56,7 @@ module "webhooks" {
 }
 
 module "web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.17.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.18.0"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -380,8 +380,8 @@ variable "alb_ingress_authenticated_listener_arns_count" {
 
 variable "authentication_type" {
   type        = "string"
-  default     = "NONE"
-  description = "Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE`"
+  default     = ""
+  description = "Authentication type. Supported values are `COGNITO` and `OIDC`"
 }
 
 variable "authentication_cognito_user_pool_arn" {


### PR DESCRIPTION
## what
* Bump `terraform-aws-ecs-web-app` version

## why
* https://github.com/cloudposse/terraform-aws-alb-ingress/pull/16
* https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/30
* Fix count logic in data sources (should be disabled when `var.enabled=false`)
