### PR TITLE
Add SSM data sources and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,16 @@ Available targets:
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
+| authentication_cognito_user_pool_arn_ssm_name | SSM param name to lookup `authentication_cognito_user_pool_arn` if not provided | string | `` | no |
 | authentication_cognito_user_pool_client_id | Cognito User Pool Client ID | string | `` | no |
+| authentication_cognito_user_pool_client_id_ssm_name | SSM param name to lookup `authentication_cognito_user_pool_client_id` if not provided | string | `` | no |
 | authentication_cognito_user_pool_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | string | `` | no |
+| authentication_cognito_user_pool_domain_ssm_name | SSM param name to lookup `authentication_cognito_user_pool_domain` if not provided | string | `` | no |
 | authentication_oidc_authorization_endpoint | OIDC Authorization Endpoint | string | `` | no |
 | authentication_oidc_client_id | OIDC Client ID | string | `` | no |
+| authentication_oidc_client_id_ssm_name | SSM param name to lookup `authentication_oidc_client_id` if not provided | string | `` | no |
 | authentication_oidc_client_secret | OIDC Client Secret | string | `` | no |
+| authentication_oidc_client_secret_ssm_name | SSM param name to lookup `authentication_oidc_client_secret` if not provided | string | `` | no |
 | authentication_oidc_issuer | OIDC Issuer | string | `` | no |
 | authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
 | authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -31,11 +31,16 @@
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
+| authentication_cognito_user_pool_arn_ssm_name | SSM param name to lookup `authentication_cognito_user_pool_arn` if not provided | string | `` | no |
 | authentication_cognito_user_pool_client_id | Cognito User Pool Client ID | string | `` | no |
+| authentication_cognito_user_pool_client_id_ssm_name | SSM param name to lookup `authentication_cognito_user_pool_client_id` if not provided | string | `` | no |
 | authentication_cognito_user_pool_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | string | `` | no |
+| authentication_cognito_user_pool_domain_ssm_name | SSM param name to lookup `authentication_cognito_user_pool_domain` if not provided | string | `` | no |
 | authentication_oidc_authorization_endpoint | OIDC Authorization Endpoint | string | `` | no |
 | authentication_oidc_client_id | OIDC Client ID | string | `` | no |
+| authentication_oidc_client_id_ssm_name | SSM param name to lookup `authentication_oidc_client_id` if not provided | string | `` | no |
 | authentication_oidc_client_secret | OIDC Client Secret | string | `` | no |
+| authentication_oidc_client_secret_ssm_name | SSM param name to lookup `authentication_oidc_client_secret` if not provided | string | `` | no |
 | authentication_oidc_issuer | OIDC Issuer | string | `` | no |
 | authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
 | authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "subnets" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.8.0"
   availability_zones  = "${local.availability_zones}"
   namespace           = "${var.namespace}"
   stage               = "${var.stage}"

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "subnets" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.8.0"
   availability_zones  = "${local.availability_zones}"
   namespace           = "${var.namespace}"
   stage               = "${var.stage}"

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 module "subnets" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.3.6"
+  source              = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.8.0"
   availability_zones  = "${local.availability_zones}"
   namespace           = "${var.namespace}"
   stage               = "${var.stage}"

--- a/variables.tf
+++ b/variables.tf
@@ -437,3 +437,33 @@ variable "authentication_oidc_user_info_endpoint" {
   description = "OIDC User Info Endpoint"
   default     = ""
 }
+
+variable "authentication_cognito_user_pool_arn_ssm_name" {
+  type        = "string"
+  description = "SSM param name to lookup `authentication_cognito_user_pool_arn` if not provided"
+  default     = ""
+}
+
+variable "authentication_cognito_user_pool_client_id_ssm_name" {
+  type        = "string"
+  description = "SSM param name to lookup `authentication_cognito_user_pool_client_id` if not provided"
+  default     = ""
+}
+
+variable "authentication_cognito_user_pool_domain_ssm_name" {
+  type        = "string"
+  description = "SSM param name to lookup `authentication_cognito_user_pool_domain` if not provided"
+  default     = ""
+}
+
+variable "authentication_oidc_client_id_ssm_name" {
+  type        = "string"
+  description = "SSM param name to lookup `authentication_oidc_client_id` if not provided"
+  default     = ""
+}
+
+variable "authentication_oidc_client_secret_ssm_name" {
+  type        = "string"
+  description = "SSM param name to lookup `authentication_oidc_client_secret` if not provided"
+  default     = ""
+}


### PR DESCRIPTION
## what
* Add SSM data sources and resources

## why
* Move it from the top-level module (`terraform-root-modules`) since `terraform-aws-ecs-atlantis` already reads and writes other parameters from/to SSM
