### PR TITLE
Remove deprecated `--allow-repo-config` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,12 @@ Available targets:
 | alb_target_group_alarms_insufficient_data_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an INSUFFICIENT_DATA state from any other state. | list | `<list>` | no |
 | alb_target_group_alarms_ok_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an OK state from any other state. | list | `<list>` | no |
 | alb_zone_id | The ID of the zone in which ALB is provisioned | string | - | yes |
-| atlantis_allow_repo_config | Allow Atlantis to use atlantis.yaml | string | `true` | no |
 | atlantis_gh_team_whitelist | Atlantis GitHub team whitelist | string | `` | no |
 | atlantis_gh_user | Atlantis GitHub user | string | - | yes |
 | atlantis_gh_webhook_secret | Atlantis GitHub webhook secret | string | `` | no |
 | atlantis_log_level | Atlantis log level | string | `info` | no |
 | atlantis_port | Atlantis container port | string | `4141` | no |
-| atlantis_repo_config | Path to atlantis config file | string | `atlantis.yaml` | no |
+| atlantis_repo_config | Path to atlantis server-side repo config file (https://www.runatlantis.io/docs/server-side-repo-config.html) | string | `atlantis-repo-config.yaml` | no |
 | atlantis_repo_whitelist | Whitelist of repositories Atlantis will accept webhooks from | list | `<list>` | no |
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,13 +19,12 @@
 | alb_target_group_alarms_insufficient_data_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an INSUFFICIENT_DATA state from any other state. | list | `<list>` | no |
 | alb_target_group_alarms_ok_actions | A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an OK state from any other state. | list | `<list>` | no |
 | alb_zone_id | The ID of the zone in which ALB is provisioned | string | - | yes |
-| atlantis_allow_repo_config | Allow Atlantis to use atlantis.yaml | string | `true` | no |
 | atlantis_gh_team_whitelist | Atlantis GitHub team whitelist | string | `` | no |
 | atlantis_gh_user | Atlantis GitHub user | string | - | yes |
 | atlantis_gh_webhook_secret | Atlantis GitHub webhook secret | string | `` | no |
 | atlantis_log_level | Atlantis log level | string | `info` | no |
 | atlantis_port | Atlantis container port | string | `4141` | no |
-| atlantis_repo_config | Path to atlantis config file | string | `atlantis.yaml` | no |
+| atlantis_repo_config | Path to atlantis server-side repo config file (https://www.runatlantis.io/docs/server-side-repo-config.html) | string | `atlantis-repo-config.yaml` | no |
 | atlantis_repo_whitelist | Whitelist of repositories Atlantis will accept webhooks from | list | `<list>` | no |
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |

--- a/main.tf
+++ b/main.tf
@@ -195,15 +195,6 @@ resource "aws_ssm_parameter" "atlantis_atlantis_url" {
   value       = "${local.atlantis_url}"
 }
 
-resource "aws_ssm_parameter" "atlantis_allow_repo_config" {
-  count       = "${local.enabled ? 1 : 0}"
-  description = "allow Atlantis to use atlantis.yaml"
-  name        = "${format(var.chamber_format, var.chamber_service, "atlantis_allow_repo_config")}"
-  overwrite   = "${var.overwrite_ssm_parameter}"
-  type        = "String"
-  value       = "${var.atlantis_allow_repo_config}"
-}
-
 resource "aws_ssm_parameter" "atlantis_gh_user" {
   count       = "${local.enabled ? 1 : 0}"
   description = "Atlantis GitHub user"

--- a/variables.tf
+++ b/variables.tf
@@ -79,8 +79,8 @@ variable "repo_owner" {
 
 variable "atlantis_repo_config" {
   type        = "string"
-  description = "Path to atlantis config file"
-  default     = "atlantis.yaml"
+  description = "Path to atlantis server-side repo config file (https://www.runatlantis.io/docs/server-side-repo-config.html)"
+  default     = "atlantis-repo-config.yaml"
 }
 
 variable "atlantis_repo_whitelist" {
@@ -120,12 +120,6 @@ variable "hostname" {
   type        = "string"
   description = "Atlantis URL"
   default     = ""
-}
-
-variable "atlantis_allow_repo_config" {
-  type        = "string"
-  description = "Allow Atlantis to use atlantis.yaml"
-  default     = "true"
 }
 
 variable "atlantis_gh_user" {


### PR DESCRIPTION
## what
* Remove deprecated `--allow-repo-config` param

## why
* Flag `--allow-repo-config` has been deprecated in favor of creating a server-side repo config file that applies the same configuration
* Use a server-side config file and point `--repo-config` to it

## references
* https://github.com/runatlantis/atlantis/releases/tag/v0.7.0
* https://www.runatlantis.io/docs/configuring-atlantis.html
* https://www.runatlantis.io/docs/server-configuration.html
* https://www.runatlantis.io/docs/server-side-repo-config.html
* https://www.runatlantis.io/docs/repo-level-atlantis-yaml.html

