### PR TITLE
Bump `terraform-aws-ecs-web-app` and `terraform-github-repository-webhooks` versions. Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Are you using this project or any of our other projects? Consider [leaving a tes
 
 Check out these related projects.
 
-- [terraform-aws-ecs-web-app](https://github.com/cloudposse/terraform-aws-ecs-web-app) - Terraform module that implements a web app on ECS and supporting AWS resources
+- [terraform-aws-ecs-web-app](https://github.com/cloudposse/terraform-aws-ecs-web-app) - Terraform module that implements a web app on ECS and supports autoscaling, CI/CD, monitoring, ALB integration, and much more
 - [terraform-aws-alb](https://github.com/cloudposse/terraform-aws-alb) - Terraform module to provision a standard ALB for HTTP/HTTP traffic
 - [terraform-aws-alb-ingress](https://github.com/cloudposse/terraform-aws-alb-ingress) - Terraform module to provision an HTTP style ingress rule based on hostname and path for an ALB
 - [terraform-aws-codebuild](https://github.com/cloudposse/terraform-aws-codebuild) - Terraform Module to easily leverage AWS CodeBuild for Continuous Integration
@@ -415,11 +415,17 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Josh Myers][joshmyers_avatar]][joshmyers_homepage]<br/>[Josh Myers][joshmyers_homepage] |
-|---|
+|  [![Josh Myers][joshmyers_avatar]][joshmyers_homepage]<br/>[Josh Myers][joshmyers_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] |
+|---|---|---|---|
 
   [joshmyers_homepage]: https://github.com/joshmyers
   [joshmyers_avatar]: https://github.com/joshmyers.png?size=150
+  [osterman_homepage]: https://github.com/osterman
+  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [aknysh_homepage]: https://github.com/aknysh
+  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [goruha_homepage]: https://github.com/goruha
+  [goruha_avatar]: https://github.com/goruha.png?size=150
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -35,10 +35,10 @@ badges:
     url: "https://slack.cloudposse.com"
 
 related:
-  - name: "terraform-aws-ecs-webapp"
+  - name: "terraform-aws-ecs-web-app"
     description: "Terraform module that implements a web app on ECS and supports autoscaling, CI/CD, monitoring, ALB integration, and much more"
     url: "https://github.com/cloudposse/terraform-aws-ecs-web-app"
-  - name: "terraform-aws-ecs-web-app"
+  - name: "terraform-aws-alb"
     description: "Terraform module to provision a standard ALB for HTTP/HTTP traffic"
     url: "https://github.com/cloudposse/terraform-aws-alb"
   - name: "terraform-aws-alb-ingress"
@@ -62,8 +62,6 @@ related:
   - name: "terraform-aws-lb-s3-bucket"
     description: "Terraform module to provision an S3 bucket with built in IAM policy to allow AWS Load Balancers to ship access logs."
     url: "https://github.com/cloudposse/terraform-aws-lb-s3-bucket"
-
-
 
 
 # Short description of this project
@@ -193,39 +191,13 @@ references:
     description: "Official home of the Atlantis project"
     url: "https://runatlantis.io"
 
-related:
-  - name: "terraform-aws-ecs-web-app"
-    description: "Terraform module that implements a web app on ECS and supporting AWS resources"
-    url: "https://github.com/cloudposse/terraform-aws-ecs-web-app"
-  - name: "terraform-aws-alb"
-    description: "Terraform module to provision a standard ALB for HTTP/HTTP traffic"
-    url: "https://github.com/cloudposse/terraform-aws-alb"
-  - name: "terraform-aws-alb-ingress"
-    description: "Terraform module to provision an HTTP style ingress rule based on hostname and path for an ALB"
-    url: "https://github.com/cloudposse/terraform-aws-alb-ingress"
-  - name: "terraform-aws-codebuild"
-    description: "Terraform Module to easily leverage AWS CodeBuild for Continuous Integration"
-    url: "https://github.com/cloudposse/terraform-aws-codebuild"
-  - name: "terraform-aws-ecr"
-    description: "Terraform Module to manage Docker Container Registries on AWS ECR"
-    url: "https://github.com/cloudposse/terraform-aws-ecr"
-  - name: "terraform-aws-ecs-alb-service-task"
-    description: "Terraform module which implements an ECS service which exposes a web service via ALB."
-    url: "https://github.com/cloudposse/terraform-aws-ecs-alb-service-task"
-  - name: "terraform-aws-ecs-codepipeline"
-    description: "Terraform Module for CI/CD with AWS Code Pipeline and Code Build for ECS"
-    url: "https://github.com/cloudposse/terraform-aws-ecs-codepipeline"
-  - name: "terraform-aws-ecs-container-definition"
-    description: "Terraform module to generate well-formed JSON documents that are passed to the aws_ecs_task_definition Terraform resource"
-    url: "https://github.com/cloudposse/terraform-aws-ecs-container-definition"
-  - name: "terraform-aws-lb-s3-bucket"
-    description: "Terraform module to provision an S3 bucket with built in IAM policy to allow AWS Load Balancers to ship access logs."
-    url: "https://github.com/cloudposse/terraform-aws-lb-s3-bucket"
-
-
-
-
 # Contributors to this project
 contributors:
   - name: "Josh Myers"
     github: "joshmyers"
+  - name: "Erik Osterman"
+    github: "osterman"
+  - name: "Andriy Knysh"
+    github: "aknysh"
+  - name: "Igor Rodionov"
+    github: "goruha"

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ module "ssh_key_pair" {
 }
 
 module "webhooks" {
-  source              = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.1.1"
+  source              = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.3.0"
   github_token        = "${local.github_oauth_token}"
   webhook_secret      = "${local.atlantis_gh_webhook_secret}"
   webhook_url         = "${local.atlantis_url}"
@@ -56,7 +56,7 @@ module "webhooks" {
 }
 
 module "web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.18.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.19.0"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"


### PR DESCRIPTION
## what
* Bump `terraform-aws-ecs-web-app` and `terraform-github-repository-webhooks` versions
* Fix README

## why
* https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/31
* https://github.com/cloudposse/terraform-aws-ecs-codepipeline/pull/23
* https://github.com/cloudposse/terraform-github-repository-webhooks/pull/8
* Fix typos and duplicated `related` in README
