### PR TITLE
Fix atlantis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Available targets:
 |------|-------------|
 | atlantis_ssh_public_key | Atlantis SSH Public Key |
 | atlantis_url | The URL endpoint for the atlantis server |
+| atlantis_webhook_url | atlantis webhook URL |
 | badge_url | The URL of the build badge when `badge_enabled` is enabled |
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -88,5 +88,6 @@
 |------|-------------|
 | atlantis_ssh_public_key | Atlantis SSH Public Key |
 | atlantis_url | The URL endpoint for the atlantis server |
+| atlantis_webhook_url | atlantis webhook URL |
 | badge_url | The URL of the build badge when `badge_enabled` is enabled |
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ data "aws_kms_key" "chamber_kms_key" {
 locals {
   enabled                     = "${var.enabled == "true" ? true : false}"
   atlantis_gh_webhook_secret  = "${length(var.atlantis_gh_webhook_secret) > 0 ? var.atlantis_gh_webhook_secret : join("", random_string.atlantis_gh_webhook_secret.*.result)}"
-  atlantis_url                = "${format(var.atlantis_webhook_format, local.hostname)}"
+  atlantis_webhook_url        = "${format(var.atlantis_webhook_format, local.hostname)}"
   attributes                  = "${concat(list(var.short_name), var.attributes)}"
   default_hostname            = "${join("", aws_route53_record.default.*.fqdn)}"
   github_oauth_token          = "${length(join("", data.aws_ssm_parameter.atlantis_gh_token.*.value)) > 0 ? join("", data.aws_ssm_parameter.atlantis_gh_token.*.value) : var.github_oauth_token}"
@@ -48,7 +48,7 @@ module "webhooks" {
   source              = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.3.0"
   github_token        = "${local.github_oauth_token}"
   webhook_secret      = "${local.atlantis_gh_webhook_secret}"
-  webhook_url         = "${local.atlantis_url}"
+  webhook_url         = "${local.atlantis_webhook_url}"
   enabled             = "${local.enabled}"
   github_organization = "${var.repo_owner}"
   github_repositories = ["${var.repo_name}"]
@@ -192,7 +192,7 @@ resource "aws_ssm_parameter" "atlantis_atlantis_url" {
   name        = "${format(var.chamber_format, var.chamber_service, "atlantis_atlantis_url")}"
   overwrite   = "${var.overwrite_ssm_parameter}"
   type        = "String"
-  value       = "${local.atlantis_url}"
+  value       = "${local.hostname}"
 }
 
 resource "aws_ssm_parameter" "atlantis_gh_user" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,10 @@ output "badge_url" {
 
 output "atlantis_url" {
   description = "The URL endpoint for the atlantis server"
-  value       = "${local.atlantis_url}"
+  value       = "${local.hostname}"
+}
+
+output "atlantis_webhook_url" {
+  description = "atlantis webhook URL"
+  value       = "${local.atlantis_webhook_url}"
 }


### PR DESCRIPTION
## what
* Fix atlantis URL

## why
* `atlantis_webhook_url` (e.g. https://atlantis.domain.com/events) is not the same as atlantis server URL (e.g. https://atlantis.domain.com)
* `atlantis_webhook_url` was written to SSM parameter store, and then sent to the atlantis server as atlantis URL (via ENV var), the atlantis server ending up generating wrong URLs in the UI (with `/events` added to all URLs on the page as prefix) - the UI did not work correctly 
