### PR TITLE
Fix `atlantis` URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Available targets:
 | atlantis_port | Atlantis container port | string | `4141` | no |
 | atlantis_repo_config | Path to atlantis server-side repo config file (https://www.runatlantis.io/docs/server-side-repo-config.html) | string | `atlantis-repo-config.yaml` | no |
 | atlantis_repo_whitelist | Whitelist of repositories Atlantis will accept webhooks from | list | `<list>` | no |
+| atlantis_url_format | Template for the Atlantis URL which is populated with the hostname | string | `https://%s` | no |
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,6 +26,7 @@
 | atlantis_port | Atlantis container port | string | `4141` | no |
 | atlantis_repo_config | Path to atlantis server-side repo config file (https://www.runatlantis.io/docs/server-side-repo-config.html) | string | `atlantis-repo-config.yaml` | no |
 | atlantis_repo_whitelist | Whitelist of repositories Atlantis will accept webhooks from | list | `<list>` | no |
+| atlantis_url_format | Template for the Atlantis URL which is populated with the hostname | string | `https://%s` | no |
 | atlantis_wake_word | Wake world for Atlantis | string | `atlantis` | no |
 | atlantis_webhook_format | Template for the Atlantis webhook URL which is populated with the hostname | string | `https://%s/events` | no |
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ locals {
   enabled                     = "${var.enabled == "true" ? true : false}"
   atlantis_gh_webhook_secret  = "${length(var.atlantis_gh_webhook_secret) > 0 ? var.atlantis_gh_webhook_secret : join("", random_string.atlantis_gh_webhook_secret.*.result)}"
   atlantis_webhook_url        = "${format(var.atlantis_webhook_format, local.hostname)}"
+  atlantis_url                = "${format(var.atlantis_url_format, local.hostname)}"
   attributes                  = "${concat(list(var.short_name), var.attributes)}"
   default_hostname            = "${join("", aws_route53_record.default.*.fqdn)}"
   github_oauth_token          = "${length(join("", data.aws_ssm_parameter.atlantis_gh_token.*.value)) > 0 ? join("", data.aws_ssm_parameter.atlantis_gh_token.*.value) : var.github_oauth_token}"
@@ -188,11 +189,11 @@ resource "aws_ssm_parameter" "atlantis_port" {
 
 resource "aws_ssm_parameter" "atlantis_atlantis_url" {
   count       = "${local.enabled ? 1 : 0}"
-  description = "URL to reach Atlantis e.g. for webhooks"
+  description = "Atlantis URL"
   name        = "${format(var.chamber_format, var.chamber_service, "atlantis_atlantis_url")}"
   overwrite   = "${var.overwrite_ssm_parameter}"
   type        = "String"
-  value       = "${local.hostname}"
+  value       = "${local.atlantis_url}"
 }
 
 resource "aws_ssm_parameter" "atlantis_gh_user" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "badge_url" {
 
 output "atlantis_url" {
   description = "The URL endpoint for the atlantis server"
-  value       = "${local.hostname}"
+  value       = "${local.atlantis_url}"
 }
 
 output "atlantis_webhook_url" {

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,12 @@ variable "atlantis_webhook_format" {
   description = "Template for the Atlantis webhook URL which is populated with the hostname"
 }
 
+variable "atlantis_url_format" {
+  type        = "string"
+  default     = "https://%s"
+  description = "Template for the Atlantis URL which is populated with the hostname"
+}
+
 variable "autoscaling_min_capacity" {
   type        = "string"
   description = "Atlantis minimum tasks to run"


### PR DESCRIPTION
## what
* Fix `atlantis` URL

## why
* `atlantis` URL requires protocol (`http` or `https`)
