### PR TITLE
Update web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ What this module does not provision:
 
 ### GitHub Repo Scopes
 
-This module accepts two GitHub tokens:
+This module accepts two GitHub OAuth tokens:
 
 1. `github_oauth_token` with permissions to pull private repos. Used by CodePipeline to clone repos before the build, and by the atlantis server to clone repos and comment on Pull Requests.
 
@@ -104,7 +104,6 @@ This module accepts two GitHub tokens:
 
 2. `github_webhooks_token` with permissions to create GitHub webhooks.
     Only used by [Terraform GitHub Provider](https://www.terraform.io/docs/providers/github/index.html) when provisioning the module.
-    It must be provided either in the `github_webhooks_token` variable, or it can also be sourced from the `GITHUB_TOKEN` environment variable.
 
     The token needs the following OAuth scopes:
 
@@ -126,6 +125,15 @@ We suggest the following steps when creating the tokens and provisioning the mod
   The CodePipeline and `atlantis` server will use the `github_oauth_token` to clone repos, which does not require escalated privileges
 
 **IMPORTANT:** Do not commit the tokens to source control (_e.g._ via `terraform.tvfars`).
+
+**NOTE:** If the two tokens are not provided (left empty), they will be looked up from SSM Parameter Store.
+You can write `atlantis atlantis_gh` and `github_webhooks_token` to SSM Parameter Store before provisioning the module.
+For example, by using [chamber](https://github.com/segmentio/chamber):
+
+```sh
+  chamber write atlantis atlantis_gh_token "....."
+  chamber write atlantis github_webhooks_token "....."
+```
 
 ## Usage
 
@@ -261,8 +269,9 @@ Available targets:
 | ecs_cluster_name | Name of the ECS cluster to deploy Atlantis | string | - | yes |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `false` | no |
 | github_oauth_token | GitHub Oauth token. If not provided the token is looked up from SSM | string | `` | no |
-| github_oauth_token_ssm_name | SSM param name to lookup GitHub OAuth token if not provided | string | `` | no |
+| github_oauth_token_ssm_name | SSM param name to lookup `github_oauth_token` if not provided | string | `` | no |
 | github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM | string | `` | no |
+| github_webhooks_token_ssm_name | SSM param name to lookup `github_webhooks_token` if not provided | string | `` | no |
 | healthcheck_path | Healthcheck path | string | `/healthz` | no |
 | hostname | Atlantis URL | string | `` | no |
 | kms_key_id | KMS key ID used to encrypt SSM SecureString parameters | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Available targets:
 | ecs_cluster_arn | ARN of the ECS cluster to deploy Atlantis | string | - | yes |
 | ecs_cluster_name | Name of the ECS cluster to deploy Atlantis | string | - | yes |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `false` | no |
-| github_oauth_token | GitHub Oauth token. If not provided the token is looked up from SSM | string | `` | no |
+| github_oauth_token | GitHub OAuth token. If not provided the token is looked up from SSM | string | `` | no |
 | github_oauth_token_ssm_name | SSM param name to lookup `github_oauth_token` if not provided | string | `` | no |
 | github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM | string | `` | no |
 | github_webhooks_token_ssm_name | SSM param name to lookup `github_webhooks_token` if not provided | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ Available targets:
 | ecs_cluster_arn | ARN of the ECS cluster to deploy Atlantis | string | - | yes |
 | ecs_cluster_name | Name of the ECS cluster to deploy Atlantis | string | - | yes |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `false` | no |
-| github_oauth_token | GitHub Oauth token. If not provided the token is looked up from SSM. | string | `` | no |
+| github_oauth_token | GitHub Oauth token. If not provided the token is looked up from SSM | string | `` | no |
 | github_oauth_token_ssm_name | SSM param name to lookup GitHub OAuth token if not provided | string | `` | no |
-| github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
+| github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM | string | `` | no |
 | healthcheck_path | Healthcheck path | string | `/healthz` | no |
 | hostname | Atlantis URL | string | `` | no |
 | kms_key_id | KMS key ID used to encrypt SSM SecureString parameters | string | `` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -111,7 +111,7 @@ introduction: |-
 
   ### GitHub Repo Scopes
 
-  This module accepts two GitHub tokens:
+  This module accepts two GitHub OAuth tokens:
 
   1. `github_oauth_token` with permissions to pull private repos. Used by CodePipeline to clone repos before the build, and by the atlantis server to clone repos and comment on Pull Requests.
 
@@ -125,7 +125,6 @@ introduction: |-
 
   2. `github_webhooks_token` with permissions to create GitHub webhooks.
       Only used by [Terraform GitHub Provider](https://www.terraform.io/docs/providers/github/index.html) when provisioning the module.
-      It must be provided either in the `github_webhooks_token` variable, or it can also be sourced from the `GITHUB_TOKEN` environment variable.
 
       The token needs the following OAuth scopes:
 
@@ -147,6 +146,15 @@ introduction: |-
     The CodePipeline and `atlantis` server will use the `github_oauth_token` to clone repos, which does not require escalated privileges
 
   **IMPORTANT:** Do not commit the tokens to source control (_e.g._ via `terraform.tvfars`).
+
+  **NOTE:** If the two tokens are not provided (left empty), they will be looked up from SSM Parameter Store.
+  You can write `atlantis atlantis_gh` and `github_webhooks_token` to SSM Parameter Store before provisioning the module.
+  For example, by using [chamber](https://github.com/segmentio/chamber):
+
+  ```sh
+    chamber write atlantis atlantis_gh_token "....."
+    chamber write atlantis github_webhooks_token "....."
+  ```
 
 # How to use this project
 usage: |-

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -61,8 +61,9 @@
 | ecs_cluster_name | Name of the ECS cluster to deploy Atlantis | string | - | yes |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `false` | no |
 | github_oauth_token | GitHub Oauth token. If not provided the token is looked up from SSM | string | `` | no |
-| github_oauth_token_ssm_name | SSM param name to lookup GitHub OAuth token if not provided | string | `` | no |
+| github_oauth_token_ssm_name | SSM param name to lookup `github_oauth_token` if not provided | string | `` | no |
 | github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM | string | `` | no |
+| github_webhooks_token_ssm_name | SSM param name to lookup `github_webhooks_token` if not provided | string | `` | no |
 | healthcheck_path | Healthcheck path | string | `/healthz` | no |
 | hostname | Atlantis URL | string | `` | no |
 | kms_key_id | KMS key ID used to encrypt SSM SecureString parameters | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -60,7 +60,7 @@
 | ecs_cluster_arn | ARN of the ECS cluster to deploy Atlantis | string | - | yes |
 | ecs_cluster_name | Name of the ECS cluster to deploy Atlantis | string | - | yes |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `false` | no |
-| github_oauth_token | GitHub Oauth token. If not provided the token is looked up from SSM | string | `` | no |
+| github_oauth_token | GitHub OAuth token. If not provided the token is looked up from SSM | string | `` | no |
 | github_oauth_token_ssm_name | SSM param name to lookup `github_oauth_token` if not provided | string | `` | no |
 | github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM | string | `` | no |
 | github_webhooks_token_ssm_name | SSM param name to lookup `github_webhooks_token` if not provided | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -60,9 +60,9 @@
 | ecs_cluster_arn | ARN of the ECS cluster to deploy Atlantis | string | - | yes |
 | ecs_cluster_name | Name of the ECS cluster to deploy Atlantis | string | - | yes |
 | enabled | Whether to create the resources. Set to `false` to prevent the module from creating any resources | string | `false` | no |
-| github_oauth_token | GitHub Oauth token. If not provided the token is looked up from SSM. | string | `` | no |
+| github_oauth_token | GitHub Oauth token. If not provided the token is looked up from SSM | string | `` | no |
 | github_oauth_token_ssm_name | SSM param name to lookup GitHub OAuth token if not provided | string | `` | no |
-| github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
+| github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM | string | `` | no |
 | healthcheck_path | Healthcheck path | string | `/healthz` | no |
 | hostname | Atlantis URL | string | `` | no |
 | kms_key_id | KMS key ID used to encrypt SSM SecureString parameters | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ module "ssh_key_pair" {
 
 module "webhooks" {
   source              = "git::https://github.com/cloudposse/terraform-github-repository-webhooks.git?ref=tags/0.4.0"
-  github_token        = "${var.github_webhooks_token}"
+  github_token        = "${local.github_webhooks_token}"
   webhook_secret      = "${local.atlantis_gh_webhook_secret}"
   webhook_url         = "${local.atlantis_webhook_url}"
   enabled             = "${local.enabled}"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,10 @@
+# Pin the `aws` provider
+# https://www.terraform.io/docs/configuration/providers.html
+# Any non-beta version >= 2.12.0 and < 2.13.0, e.g. 2.12.X
+provider "aws" {
+  version = "~> 2.12.0"
+}
+
 # Terraform
 #--------------------------------------------------------------
 terraform {

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ module "webhooks" {
 }
 
 module "web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=update-codepipeline"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.22.0"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ module "webhooks" {
 }
 
 module "web_app" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=tags/0.21.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=update-codepipeline"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 # Terraform
 #--------------------------------------------------------------
 terraform {
-  required_version = ">= 0.10.7"
+  required_version = "~> 0.11.0"
 }
 
 # Data

--- a/variables.tf
+++ b/variables.tf
@@ -40,19 +40,25 @@ variable "default_backend_image" {
 
 variable "github_oauth_token" {
   type        = "string"
-  description = "GitHub Oauth token. If not provided the token is looked up from SSM."
+  description = "GitHub Oauth token. If not provided the token is looked up from SSM"
   default     = ""
 }
 
 variable "github_webhooks_token" {
   type        = "string"
-  description = "GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable"
+  description = "GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM"
   default     = ""
 }
 
 variable "github_oauth_token_ssm_name" {
   type        = "string"
-  description = "SSM param name to lookup GitHub OAuth token if not provided"
+  description = "SSM param name to lookup `github_oauth_token` if not provided"
+  default     = ""
+}
+
+variable "github_webhooks_token_ssm_name" {
+  type        = "string"
+  description = "SSM param name to lookup `github_webhooks_token` if not provided"
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "default_backend_image" {
 
 variable "github_oauth_token" {
   type        = "string"
-  description = "GitHub Oauth token. If not provided the token is looked up from SSM"
+  description = "GitHub OAuth token. If not provided the token is looked up from SSM"
   default     = ""
 }
 


### PR DESCRIPTION
## what
* Update `web-app` version
* Add `github_webhooks_token`
* Pin `aws` provider

## why
* https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/34
* Read the GitHub webhooks token from SSM Parameter Store (similar to `atlantis_gh_token`). GitHub provider does not accept an empty token (https://github.com/cloudposse/terraform-github-repository-webhooks/blob/master/main.tf#L2). It should either be provided or the attribute omitted completely if the token is needed to be sourced from the `GITHUB_TOKEN` env variable
* Consistency, reproducibility
