### PR TITLE
Pin GitHub provider to 3.0.0

### DIFF
--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request::true"
+            echo "::set-output name=create_pull_request=true"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
@@ -38,8 +38,6 @@ jobs:
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
-        author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source
         title: Update context.tf
         body: |-

--- a/README.md
+++ b/README.md
@@ -156,6 +156,25 @@ For example, by using [chamber](https://github.com/segmentio/chamber):
   chamber write atlantis github_webhooks_token "....."
 ```
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 

--- a/README.md
+++ b/README.md
@@ -156,25 +156,6 @@ For example, by using [chamber](https://github.com/segmentio/chamber):
   chamber write atlantis github_webhooks_token "....."
 ```
 
-## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
-
-Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
-
-| Benchmark | Description |
-|--------|---------------|
-| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
-| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
-| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
-| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
-| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
-| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
-| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
-| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=SOC2)| Service Organization Control 2 Compliance |
-| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
-| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
-
-
-
 ## Usage
 
 
@@ -425,7 +406,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | random | >= 2.0 |
 
@@ -496,7 +477,7 @@ Available targets:
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | container\_cpu | Atlantis CPUs per task | `number` | `256` | no |
 | container\_memory | Atlantis memory per task | `number` | `512` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>    label_key_case      = string<br>    label_value_case    = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | default\_backend\_image | ECS default (bootstrap) image | `string` | `"cloudposse/default-backend:0.1.2"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | desired\_count | Atlantis desired number of tasks | `number` | `1` | no |
@@ -521,9 +502,7 @@ Available targets:
 | hostname | Atlantis URL | `string` | `""` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | kms\_key\_id | KMS key ID used to encrypt SSM SecureString parameters | `string` | `""` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`. <br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation). <br>Default value: `lower`. | `string` | `null` | no |
 | launch\_type | The ECS launch type (valid options: FARGATE or EC2) | `string` | `"FARGATE"` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,25 @@ For example, by using [chamber](https://github.com/segmentio/chamber):
   chamber write atlantis github_webhooks_token "....."
 ```
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-ecs-atlantis/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-ecs-atlantis&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 
@@ -494,7 +513,6 @@ Available targets:
 | ecs\_cluster\_name | Name of the ECS cluster to deploy Atlantis | `string` | n/a | yes |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| github\_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB\_TOKEN or `github_token`) | `bool` | `false` | no |
 | github\_oauth\_token | GitHub OAuth token. If not provided the token is looked up from SSM | `string` | `""` | no |
 | github\_oauth\_token\_ssm\_name | SSM param name to lookup `github_oauth_token` if not provided | `string` | `""` | no |
 | github\_webhooks\_token | GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM | `string` | `""` | no |

--- a/context.tf
+++ b/context.tf
@@ -20,7 +20,7 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.23.0" // requires Terraform >= 0.13.0
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace
@@ -54,8 +54,6 @@ variable "context" {
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
-    label_key_case      = string
-    label_value_case    = string
   })
   default = {
     enabled             = true
@@ -70,8 +68,6 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
-    label_key_case      = null
-    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -80,16 +76,6 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
-
-  validation {
-    condition     = var.context["label_key_case"] == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-
-  validation {
-    condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
 }
 
 variable "enabled" {
@@ -179,33 +165,4 @@ variable "id_length_limit" {
   EOT
 }
 
-variable "label_key_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
-    Possible values: `lower`, `title`, `upper`. 
-    Default value: `title`.
-  EOT
-
-  validation {
-    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-}
-
-variable "label_value_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of output label values (also used in `tags` and `id`).
-    Possible values: `lower`, `title`, `upper` and `none` (no transformation). 
-    Default value: `lower`.
-  EOT
-
-  validation {
-    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
-}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -91,7 +91,6 @@
 | ecs\_cluster\_name | Name of the ECS cluster to deploy Atlantis | `string` | n/a | yes |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| github\_anonymous | Github Anonymous API (if `true`, token must not be set as GITHUB\_TOKEN or `github_token`) | `bool` | `false` | no |
 | github\_oauth\_token | GitHub OAuth token. If not provided the token is looked up from SSM | `string` | `""` | no |
 | github\_oauth\_token\_ssm\_name | SSM param name to lookup `github_oauth_token` if not provided | `string` | `""` | no |
 | github\_webhooks\_token | GitHub OAuth Token with permissions to create webhooks. If not provided the token is looked up from SSM | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | random | >= 2.0 |
 
@@ -74,7 +74,7 @@
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | container\_cpu | Atlantis CPUs per task | `number` | `256` | no |
 | container\_memory | Atlantis memory per task | `number` | `512` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>    label_key_case      = string<br>    label_value_case    = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | default\_backend\_image | ECS default (bootstrap) image | `string` | `"cloudposse/default-backend:0.1.2"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | desired\_count | Atlantis desired number of tasks | `number` | `1` | no |
@@ -99,9 +99,7 @@
 | hostname | Atlantis URL | `string` | `""` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | kms\_key\_id | KMS key ID used to encrypt SSM SecureString parameters | `string` | `""` | no |
-| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`. <br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
-| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation). <br>Default value: `lower`. | `string` | `null` | no |
 | launch\_type | The ECS launch type (valid options: FARGATE or EC2) | `string` | `"FARGATE"` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -20,7 +20,7 @@
 
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.23.0" // requires Terraform >= 0.13.0
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace
@@ -54,8 +54,6 @@ variable "context" {
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
-    label_key_case      = string
-    label_value_case    = string
   })
   default = {
     enabled             = true
@@ -70,8 +68,6 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
-    label_key_case      = null
-    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -80,16 +76,6 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
-
-  validation {
-    condition     = var.context["label_key_case"] == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-
-  validation {
-    condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
 }
 
 variable "enabled" {
@@ -179,33 +165,4 @@ variable "id_length_limit" {
   EOT
 }
 
-variable "label_key_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
-    Possible values: `lower`, `title`, `upper`. 
-    Default value: `title`.
-  EOT
-
-  validation {
-    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`."
-  }
-}
-
-variable "label_value_case" {
-  type        = string
-  default     = null
-  description = <<-EOT
-    The letter case of output label values (also used in `tags` and `id`).
-    Possible values: `lower`, `title`, `upper` and `none` (no transformation). 
-    Default value: `lower`.
-  EOT
-
-  validation {
-    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
-    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
-  }
-}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -67,6 +67,26 @@ module "kms_key" {
   context = module.this.context
 }
 
+module "atlantis_dns_name" {
+  source  = "cloudposse/label/null"
+  version = "0.22.1"
+
+  name = var.short_name
+  attributes = module.this.attributes
+
+  # Omission of context = module.this.context is intentional
+}
+
+module "atlantis_chamber_service" {
+  source  = "cloudposse/label/null"
+  version = "0.22.1"
+
+  name = var.chamber_service
+  attributes = module.this.attributes
+
+  # Omission of context = module.this.context is intentional
+}
+
 module "atlantis" {
   source = "../.."
 
@@ -76,7 +96,7 @@ module "atlantis" {
   ssh_private_key_name = var.ssh_private_key_name
   ssh_public_key_name  = var.ssh_public_key_name
   kms_key_id           = var.kms_key_id == "" ? module.kms_key.key_id : var.kms_key_id
-  chamber_service      = var.chamber_service
+  chamber_service      = module.atlantis_chamber_service.id
 
   atlantis_gh_user           = var.atlantis_gh_user
   atlantis_gh_team_whitelist = var.atlantis_gh_team_whitelist
@@ -90,7 +110,7 @@ module "atlantis" {
 
   default_backend_image = var.default_backend_image
   healthcheck_path      = var.healthcheck_path
-  short_name            = var.short_name
+  short_name            = module.atlantis_dns_name.id
   hostname              = var.hostname
   parent_zone_id        = var.parent_zone_id
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -94,11 +94,11 @@ module "atlantis" {
   hostname              = var.hostname
   parent_zone_id        = var.parent_zone_id
 
-  // Container
+  # Container
   container_cpu    = var.container_cpu
   container_memory = var.container_memory
 
-  // Authentication
+  # Authentication
   authentication_type                           = var.authentication_type
   alb_ingress_listener_unauthenticated_priority = var.alb_ingress_listener_unauthenticated_priority
   alb_ingress_listener_authenticated_priority   = var.alb_ingress_listener_authenticated_priority
@@ -116,7 +116,7 @@ module "atlantis" {
   authentication_oidc_token_endpoint            = var.authentication_oidc_token_endpoint
   authentication_oidc_user_info_endpoint        = var.authentication_oidc_user_info_endpoint
 
-  // ECS
+  # ECS
   private_subnet_ids = module.subnets.private_subnet_ids
   ecs_cluster_arn    = aws_ecs_cluster.default.arn
   ecs_cluster_name   = aws_ecs_cluster.default.name
@@ -124,7 +124,7 @@ module "atlantis" {
   desired_count      = var.desired_count
   launch_type        = var.launch_type
 
-  // ALB
+  # ALB
   alb_zone_id                                     = module.alb.alb_zone_id
   alb_arn_suffix                                  = module.alb.alb_arn_suffix
   alb_dns_name                                    = module.alb.alb_dns_name
@@ -132,7 +132,7 @@ module "atlantis" {
   alb_ingress_unauthenticated_listener_arns       = [module.alb.http_listener_arn]
   alb_ingress_unauthenticated_listener_arns_count = 1
 
-  // CodePipeline
+  # CodePipeline
   codepipeline_enabled                 = var.codepipeline_enabled
   github_oauth_token                   = var.github_oauth_token
   github_webhooks_token                = var.github_webhooks_token
@@ -145,12 +145,12 @@ module "atlantis" {
   webhook_events                       = var.webhook_events
   codepipeline_s3_bucket_force_destroy = var.codepipeline_s3_bucket_force_destroy
 
-  // Autoscaling
+  # Autoscaling
   autoscaling_enabled      = var.autoscaling_enabled
   autoscaling_min_capacity = var.autoscaling_min_capacity
   autoscaling_max_capacity = var.autoscaling_max_capacity
 
-  // Alarms
+  # Alarms
   alb_target_group_alarms_enabled                   = var.alb_target_group_alarms_enabled
   ecs_alarms_enabled                                = var.ecs_alarms_enabled
   alb_target_group_alarms_alarm_actions             = [aws_sns_topic.sns_topic.arn]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -94,11 +94,11 @@ module "atlantis" {
   hostname              = var.hostname
   parent_zone_id        = var.parent_zone_id
 
-  # Container
+  // Container
   container_cpu    = var.container_cpu
   container_memory = var.container_memory
 
-  # Authentication
+  // Authentication
   authentication_type                           = var.authentication_type
   alb_ingress_listener_unauthenticated_priority = var.alb_ingress_listener_unauthenticated_priority
   alb_ingress_listener_authenticated_priority   = var.alb_ingress_listener_authenticated_priority
@@ -116,7 +116,7 @@ module "atlantis" {
   authentication_oidc_token_endpoint            = var.authentication_oidc_token_endpoint
   authentication_oidc_user_info_endpoint        = var.authentication_oidc_user_info_endpoint
 
-  # ECS
+  // ECS
   private_subnet_ids = module.subnets.private_subnet_ids
   ecs_cluster_arn    = aws_ecs_cluster.default.arn
   ecs_cluster_name   = aws_ecs_cluster.default.name
@@ -124,7 +124,7 @@ module "atlantis" {
   desired_count      = var.desired_count
   launch_type        = var.launch_type
 
-  # ALB
+  // ALB
   alb_zone_id                                     = module.alb.alb_zone_id
   alb_arn_suffix                                  = module.alb.alb_arn_suffix
   alb_dns_name                                    = module.alb.alb_dns_name
@@ -132,7 +132,7 @@ module "atlantis" {
   alb_ingress_unauthenticated_listener_arns       = [module.alb.http_listener_arn]
   alb_ingress_unauthenticated_listener_arns_count = 1
 
-  # CodePipeline
+  // CodePipeline
   codepipeline_enabled                 = var.codepipeline_enabled
   github_oauth_token                   = var.github_oauth_token
   github_webhooks_token                = var.github_webhooks_token
@@ -145,12 +145,12 @@ module "atlantis" {
   webhook_events                       = var.webhook_events
   codepipeline_s3_bucket_force_destroy = var.codepipeline_s3_bucket_force_destroy
 
-  # Autoscaling
+  // Autoscaling
   autoscaling_enabled      = var.autoscaling_enabled
   autoscaling_min_capacity = var.autoscaling_min_capacity
   autoscaling_max_capacity = var.autoscaling_max_capacity
 
-  # Alarms
+  // Alarms
   alb_target_group_alarms_enabled                   = var.alb_target_group_alarms_enabled
   ecs_alarms_enabled                                = var.ecs_alarms_enabled
   alb_target_group_alarms_alarm_actions             = [aws_sns_topic.sns_topic.arn]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -77,16 +77,6 @@ module "atlantis_dns_name" {
   # Omission of context = module.this.context is intentional
 }
 
-module "atlantis_chamber_service" {
-  source  = "cloudposse/label/null"
-  version = "0.22.1"
-
-  name = var.chamber_service
-  attributes = module.this.attributes
-
-  # Omission of context = module.this.context is intentional
-}
-
 module "atlantis" {
   source = "../.."
 
@@ -96,7 +86,7 @@ module "atlantis" {
   ssh_private_key_name = var.ssh_private_key_name
   ssh_public_key_name  = var.ssh_public_key_name
   kms_key_id           = var.kms_key_id == "" ? module.kms_key.key_id : var.kms_key_id
-  chamber_service      = module.atlantis_chamber_service.id
+  chamber_service      = var.chamber_service
 
   atlantis_gh_user           = var.atlantis_gh_user
   atlantis_gh_team_whitelist = var.atlantis_gh_team_whitelist

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {

--- a/examples/with_cognito_authentication/versions.tf
+++ b/examples/with_cognito_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {

--- a/examples/with_google_oidc_authentication/versions.tf
+++ b/examples/with_google_oidc_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {

--- a/examples/without_authentication/versions.tf
+++ b/examples/without_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ module "github_webhooks" {
 
 module "ecs_web_app" {
   source  = "cloudposse/ecs-web-app/aws"
-  version = "0.48.1"
+  version = "0.48.2"
 
   region      = var.region
   vpc_id      = var.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -51,9 +51,8 @@ module "ssh_key_pair" {
 
 module "github_webhooks" {
   source               = "cloudposse/repository-webhooks/github"
-  version              = "0.10.0"
+  version              = "0.11.0"
   enabled              = local.enabled && var.webhook_enabled ? true : false
-  github_anonymous     = var.github_anonymous
   github_organization  = var.repo_owner
   github_repositories  = [var.repo_name]
   github_token         = local.github_webhooks_token
@@ -62,12 +61,12 @@ module "github_webhooks" {
   webhook_content_type = "json"
   events               = var.webhook_events
 
-  //  context = module.this.context
+  context = module.this.context
 }
 
 module "ecs_web_app" {
   source  = "cloudposse/ecs-web-app/aws"
-  version = "0.48.2"
+  version = "0.52.0"
 
   region      = var.region
   vpc_id      = var.vpc_id

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -233,10 +233,10 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	atlantisUrl := terraform.Output(t, terraformOptions, "atlantis_url")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "https://ecs-atlantis-test.testing.cloudposse.co", atlantisUrl)
+	assert.Equal(t, "https://ecs-atlantis-test-" + attributes[0] +".testing.cloudposse.co", atlantisUrl)
 
 	// Run `terraform output` to get the value of an output variable
 	atlantisWebhookUrl := terraform.Output(t, terraformOptions, "atlantis_webhook_url")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "https://ecs-atlantis-test.testing.cloudposse.co/events", atlantisWebhookUrl)
+	assert.Equal(t, "https://ecs-atlantis-test-" + attributes[0] +".testing.cloudposse.co/events", atlantisWebhookUrl)
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -113,19 +113,19 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	codebuildCacheBucketName := terraform.Output(t, terraformOptions, "codebuild_cache_bucket_name")
 	// Verify we're getting back the outputs we expect
-	expectedCodebuildCacheBucketName := "eg-test-ecs-atlantis-build-" + attributes[0]
+	expectedCodebuildCacheBucketName := "eg-test-ecs-atlantis-" + attributes[0] + "-build"
 	assert.Contains(t, codebuildCacheBucketName, expectedCodebuildCacheBucketName)
 
 	// Run `terraform output` to get the value of an output variable
 	codebuildProjectName := terraform.Output(t, terraformOptions, "codebuild_project_name")
 	// Verify we're getting back the outputs we expect
-	expectedCodebuildProjectName := "eg-test-ecs-atlantis-build-" + attributes[0]
+	expectedCodebuildProjectName := "eg-test-ecs-atlantis-" + attributes[0] + "-build"
 	assert.Equal(t, expectedCodebuildProjectName, codebuildProjectName)
 
 	// Run `terraform output` to get the value of an output variable
 	codebuildRoleId := terraform.Output(t, terraformOptions, "codebuild_role_id")
 	// Verify we're getting back the outputs we expect
-	expectedCodebuildRoleId := "eg-test-ecs-atlantis-build-" + attributes[0]
+	expectedCodebuildRoleId := "eg-test-ecs-atlantis-" + attributes[0] + "-build"
 	assert.Equal(t, expectedCodebuildRoleId, codebuildRoleId)
 
 	// Run `terraform output` to get the value of an output variable

--- a/variables.tf
+++ b/variables.tf
@@ -27,12 +27,6 @@ variable "github_webhooks_token" {
   default     = ""
 }
 
-variable "github_anonymous" {
-  type        = bool
-  description = "Github Anonymous API (if `true`, token must not be set as GITHUB_TOKEN or `github_token`)"
-  default     = false
-}
-
 variable "github_oauth_token_ssm_name" {
   type        = string
   description = "SSM param name to lookup `github_oauth_token` if not provided"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what
- Restore TF 0.12 support
- Remove `github_anonymous`
- Use modules pinned to GitHub provider 3.0.0

## why
- Update/fix TF 0.12 compatible module before dropping support for TF 0.12
- GitHub provider dropped support for `github_anonymous`
- GitHub provider has breaking changes with every release, 3.0.0 seemed the best balance of stable, bug-free, and compatible with our codebase