### PR TITLE
Make vars sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -46,11 +46,13 @@ output "alb_ingress_target_group_arn_suffix" {
 output "container_definition_json" {
   description = "JSON encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition"
   value       = module.ecs_web_app.container_definition_json
+  sensitive   = true
 }
 
 output "container_definition_json_map" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition"
   value       = module.ecs_web_app.container_definition_json_map
+  sensitive   = true
 }
 
 output "ecs_exec_role_policy_id" {


### PR DESCRIPTION
https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/113 <-- That PR broke this module.

## what
* mark sensitive outputs sensitive

## why
* current module doesn't work with tf 0.14

```
Error: Output refers to sensitive values

  on outputs.tf line 46:
  46: output "container_definition_json" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.


Error: Output refers to sensitive values

  on outputs.tf line 51:
  51: output "container_definition_json_map" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.
```
